### PR TITLE
LPS-19613 Query error using DISTINCT and ORDER BY

### DIFF
--- a/portal-service/src/com/liferay/portal/util/comparator/LayoutComparator.java
+++ b/portal-service/src/com/liferay/portal/util/comparator/LayoutComparator.java
@@ -22,9 +22,11 @@ import com.liferay.portal.model.Layout;
  */
 public class LayoutComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "groupId ASC, layoutId ASC";
+	public static String ORDER_BY_ASC =
+		"Layout.groupId ASC, Layout.layoutId ASC";
 
-	public static String ORDER_BY_DESC = "groupId DESC, layoutId DESC";
+	public static String ORDER_BY_DESC =
+		"Layout.groupId DESC, Layout.layoutId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"groupId", "layoutId"};
 

--- a/portal-service/src/com/liferay/portal/util/comparator/LayoutPriorityComparator.java
+++ b/portal-service/src/com/liferay/portal/util/comparator/LayoutPriorityComparator.java
@@ -22,7 +22,7 @@ import com.liferay.portal.model.Layout;
  */
 public class LayoutPriorityComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "priority ASC";
+	public static String ORDER_BY_ASC = "Layout.priority ASC";
 
 	public static String[] ORDER_BY_FIELDS = {"priority"};
 

--- a/portal-service/src/com/liferay/portal/util/comparator/PermissionComparator.java
+++ b/portal-service/src/com/liferay/portal/util/comparator/PermissionComparator.java
@@ -22,7 +22,7 @@ import com.liferay.portal.model.Permission;
  */
 public class PermissionComparator extends OrderByComparator {
 
-	public static String ORDER_BY_DESC = "permissionId DESC";
+	public static String ORDER_BY_DESC = "Permission_.permissionId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"permissionId"};
 

--- a/portal-service/src/com/liferay/portal/util/comparator/ResourceComparator.java
+++ b/portal-service/src/com/liferay/portal/util/comparator/ResourceComparator.java
@@ -22,7 +22,7 @@ import com.liferay.portal.model.Resource;
  */
 public class ResourceComparator extends OrderByComparator {
 
-	public static String ORDER_BY_DESC = "resourceId DESC";
+	public static String ORDER_BY_DESC = "Resource_.resourceId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"resourceId"};
 

--- a/portal-service/src/com/liferay/portal/util/comparator/SubscriptionClassNameIdComparator.java
+++ b/portal-service/src/com/liferay/portal/util/comparator/SubscriptionClassNameIdComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portal.model.Subscription;
  */
 public class SubscriptionClassNameIdComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "classNameId ASC";
+	public static String ORDER_BY_ASC = "Subscription.classNameId ASC";
 
-	public static String ORDER_BY_DESC = "classNameId DESC";
+	public static String ORDER_BY_DESC = "Subscription.classNameId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"classNameId"};
 

--- a/portal-service/src/com/liferay/portlet/asset/util/comparator/AssetTagCountComparator.java
+++ b/portal-service/src/com/liferay/portlet/asset/util/comparator/AssetTagCountComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.asset.model.AssetTag;
  */
 public class AssetTagCountComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "assetCount ASC";
+	public static String ORDER_BY_ASC = "AssetTag.assetCount ASC";
 
-	public static String ORDER_BY_DESC = "assetCount DESC";
+	public static String ORDER_BY_DESC = "AssetTag.assetCount DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"assetCount"};
 

--- a/portal-service/src/com/liferay/portlet/blogs/util/comparator/EntryDisplayDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/blogs/util/comparator/EntryDisplayDateComparator.java
@@ -23,9 +23,11 @@ import com.liferay.portlet.blogs.model.BlogsEntry;
  */
 public class EntryDisplayDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "displayDate ASC, entryId ASC";
+	public static String ORDER_BY_ASC =
+		"BlogsEntry.displayDate ASC, BlogsEntry.entryId ASC";
 
-	public static String ORDER_BY_DESC = "displayDate DESC, entryId DESC";
+	public static String ORDER_BY_DESC =
+		"BlogsEntry.displayDate DESC, BlogsEntry.entryId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"displayDate", "entryId"};
 

--- a/portal-service/src/com/liferay/portlet/blogs/util/comparator/StatsUserLastPostDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/blogs/util/comparator/StatsUserLastPostDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.blogs.model.BlogsStatsUser;
  */
 public class StatsUserLastPostDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "lastPostDate ASC";
+	public static String ORDER_BY_ASC = "BlogsStatsUser.lastPostDate ASC";
 
-	public static String ORDER_BY_DESC = "lastPostDate DESC";
+	public static String ORDER_BY_DESC = "BlogsStatsUser.lastPostDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"lastPostDate"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryModifiedDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryModifiedDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryModifiedDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "modifiedDate ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.modifiedDate ASC";
 
-	public static String ORDER_BY_DESC = "modifiedDate DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.modifiedDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"modifiedDate"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryNameComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryNameComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryNameComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "name ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.name ASC";
 
-	public static String ORDER_BY_DESC = "name DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.name DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"name"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryPriorityComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryPriorityComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryPriorityComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "priority ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.priority ASC";
 
-	public static String ORDER_BY_DESC = "priority DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.priority DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"priority"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryURLComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryURLComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryURLComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "url ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.url ASC";
 
-	public static String ORDER_BY_DESC = "url DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.url DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"url"};
 

--- a/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryVisitsComparator.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/util/comparator/EntryVisitsComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
  */
 public class EntryVisitsComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "visits ASC";
+	public static String ORDER_BY_ASC = "BookmarksEntry.visits ASC";
 
-	public static String ORDER_BY_DESC = "visits DESC";
+	public static String ORDER_BY_DESC = "BookmarksEntry.visits DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"visits"};
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/comparator/FileRankCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/comparator/FileRankCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.documentlibrary.model.DLFileRank;
  */
 public class FileRankCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "DLFileRank.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "DLFileRank.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.imagegallery.model.IGImage;
  */
 public class ImageCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "IGImage.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "IGImage.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageDescriptionComparator.java
+++ b/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageDescriptionComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.imagegallery.model.IGImage;
  */
 public class ImageDescriptionComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "description ASC";
+	public static String ORDER_BY_ASC = "IGImage.description ASC";
 
-	public static String ORDER_BY_DESC = "description DESC";
+	public static String ORDER_BY_DESC = "IGImage.description DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"description"};
 

--- a/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageModifiedDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/imagegallery/util/comparator/ImageModifiedDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.imagegallery.model.IGImage;
  */
 public class ImageModifiedDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "modifiedDate ASC";
+	public static String ORDER_BY_ASC = "IGImage.modifiedDate ASC";
 
-	public static String ORDER_BY_DESC = "modifiedDate DESC";
+	public static String ORDER_BY_DESC = "IGImage.modifiedDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"modifiedDate"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "JournalArticle.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "JournalArticle.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleDisplayDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleDisplayDateComparator.java
@@ -23,9 +23,11 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleDisplayDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "displayDate ASC, version ASC";
+	public static String ORDER_BY_ASC = 
+		"JournalArticle.displayDate ASC, JournalArticle.version ASC";
 
-	public static String ORDER_BY_DESC = "displayDate DESC, version DESC";
+	public static String ORDER_BY_DESC = 
+		"JournalArticle.displayDate DESC, JournalArticle.version DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"displayDate", "version"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleModifiedDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleModifiedDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleModifiedDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "modifiedDate ASC";
+	public static String ORDER_BY_ASC = "JournalArticle.modifiedDate ASC";
 
-	public static String ORDER_BY_DESC = "modifiedDate DESC";
+	public static String ORDER_BY_DESC = "JournalArticle.modifiedDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"modifiedDate"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleReviewDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleReviewDateComparator.java
@@ -23,9 +23,11 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleReviewDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "reviewDate ASC, version ASC";
+	public static String ORDER_BY_ASC = 
+		"JournalArticle.reviewDate ASC, JournalArticle.version ASC";
 
-	public static String ORDER_BY_DESC = "reviewDate DESC, version DESC";
+	public static String ORDER_BY_DESC = 
+		"JournalArticle.reviewDate DESC, JournalArticle.version DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"reviewDate", "version"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleTitleComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleTitleComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleTitleComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "title ASC";
+	public static String ORDER_BY_ASC = "JournalArticle.title ASC";
 
-	public static String ORDER_BY_DESC = "title DESC";
+	public static String ORDER_BY_DESC = "JournalArticle.title DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"title"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleVersionComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/ArticleVersionComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.journal.model.JournalArticle;
  */
 public class ArticleVersionComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "version ASC";
+	public static String ORDER_BY_ASC = "JournalArticle.version ASC";
 
-	public static String ORDER_BY_DESC = "version DESC";
+	public static String ORDER_BY_DESC = "JournalArticle.version DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"version"};
 

--- a/portal-service/src/com/liferay/portlet/journal/util/comparator/StructurePKComparator.java
+++ b/portal-service/src/com/liferay/portlet/journal/util/comparator/StructurePKComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.journal.model.JournalStructure;
  */
 public class StructurePKComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "id ASC";
+	public static String ORDER_BY_ASC = "JournalStructure.id ASC";
 
-	public static String ORDER_BY_DESC = "id DESC";
+	public static String ORDER_BY_DESC = "JournalStructure.id DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"id"};
 

--- a/portal-service/src/com/liferay/portlet/messageboards/util/comparator/MessageCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/util/comparator/MessageCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.messageboards.model.MBMessage;
  */
 public class MessageCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "MBMessage.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "MBMessage.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/messageboards/util/comparator/ThreadLastPostDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/util/comparator/ThreadLastPostDateComparator.java
@@ -27,9 +27,11 @@ import java.util.Date;
  */
 public class ThreadLastPostDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "lastPostDate ASC, threadId ASC";
+	public static String ORDER_BY_ASC = 
+		"MBThread.lastPostDate ASC, MBThread.threadId ASC";
 
-	public static String ORDER_BY_DESC = "lastPostDate DESC, threadId DESC";
+	public static String ORDER_BY_DESC = 
+		"MBThread.lastPostDate DESC, MBThread.threadId DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"lastPostDate", "threadId"};
 

--- a/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemMinQuantityComparator.java
+++ b/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemMinQuantityComparator.java
@@ -23,10 +23,12 @@ import com.liferay.portlet.shopping.model.ShoppingItem;
 public class ItemMinQuantityComparator extends OrderByComparator {
 
 	public static String ORDER_BY_ASC =
-		"categoryId ASC, minQuantity ASC, name ASC";
+		"ShoppingItem.categoryId ASC, ShoppingItem.minQuantity ASC, " +
+			"ShoppingItem.name ASC";
 
 	public static String ORDER_BY_DESC =
-		"categoryId DESC, minQuantity DESC, name DESC";
+		"ShoppingItem.categoryId DESC, ShoppingItem.minQuantity DESC, " +
+			"ShoppingItem.name DESC";
 
 	public static String[] ORDER_BY_FIELDS = {
 		"categoryId", "minQuantity", "name"

--- a/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemNameComparator.java
+++ b/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemNameComparator.java
@@ -22,9 +22,11 @@ import com.liferay.portlet.shopping.model.ShoppingItem;
  */
 public class ItemNameComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "categoryId ASC, name ASC";
+	public static String ORDER_BY_ASC =
+		"ShoppingItem.categoryId ASC, ShoppingItem.name ASC";
 
-	public static String ORDER_BY_DESC = "categoryId DESC, name DESC";
+	public static String ORDER_BY_DESC =
+		"ShoppingItem.categoryId DESC, ShoppingItem.name DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"categoryId", "name"};
 

--- a/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemPriceComparator.java
+++ b/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemPriceComparator.java
@@ -22,10 +22,13 @@ import com.liferay.portlet.shopping.model.ShoppingItem;
  */
 public class ItemPriceComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "categoryId ASC, price ASC, name ASC";
+	public static String ORDER_BY_ASC = 
+		"ShoppingItem.categoryId ASC, ShoppingItem.price ASC, " +
+			"ShoppingItem.name ASC";
 
 	public static String ORDER_BY_DESC =
-		"categoryId DESC, price DESC, name DESC";
+		"ShoppingItem.categoryId DESC, ShoppingItem.price DESC, " +
+			"ShoppingItem.name DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"categoryId", "price", "name"};
 

--- a/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemSKUComparator.java
+++ b/portal-service/src/com/liferay/portlet/shopping/util/comparator/ItemSKUComparator.java
@@ -22,9 +22,11 @@ import com.liferay.portlet.shopping.model.ShoppingItem;
  */
 public class ItemSKUComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "categoryId ASC, sku ASC";
+	public static String ORDER_BY_ASC = 
+		"ShoppingItem.categoryId ASC, ShoppingItem.sku ASC";
 
-	public static String ORDER_BY_DESC = "categoryId DESC, sku DESC";
+	public static String ORDER_BY_DESC = 
+		"ShoppingItem.categoryId DESC, ShoppingItem.sku DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"categoryId", "sku"};
 

--- a/portal-service/src/com/liferay/portlet/shopping/util/comparator/OrderDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/shopping/util/comparator/OrderDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.shopping.model.ShoppingOrder;
  */
 public class OrderDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "ShoppingOrder.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "ShoppingOrder.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.softwarecatalog.model.SCProductEntry;
  */
 public class ProductEntryCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "SCProductEntry.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "SCProductEntry.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryModifiedDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryModifiedDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.softwarecatalog.model.SCProductEntry;
  */
 public class ProductEntryModifiedDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "modifiedDate ASC";
+	public static String ORDER_BY_ASC = "SCProductEntry.modifiedDate ASC";
 
-	public static String ORDER_BY_DESC = "modifiedDate DESC";
+	public static String ORDER_BY_DESC = "SCProductEntry.modifiedDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"modifiedDate"};
 

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryNameComparator.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryNameComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.softwarecatalog.model.SCProductEntry;
  */
 public class ProductEntryNameComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "name ASC";
+	public static String ORDER_BY_ASC = "SCProductEntry.name ASC";
 
-	public static String ORDER_BY_DESC = "name DESC";
+	public static String ORDER_BY_DESC = "SCProductEntry.name DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"name"};
 

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryTypeComparator.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/util/comparator/ProductEntryTypeComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.softwarecatalog.model.SCProductEntry;
  */
 public class ProductEntryTypeComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "type_ ASC";
+	public static String ORDER_BY_ASC = "SCProductEntry.type_ ASC";
 
-	public static String ORDER_BY_DESC = "type_ DESC";
+	public static String ORDER_BY_DESC = "SCProductEntry.type_ DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"type"};
 

--- a/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageCreateDateComparator.java
+++ b/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageCreateDateComparator.java
@@ -23,9 +23,9 @@ import com.liferay.portlet.wiki.model.WikiPage;
  */
 public class PageCreateDateComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "createDate ASC";
+	public static String ORDER_BY_ASC = "WikiPage.createDate ASC";
 
-	public static String ORDER_BY_DESC = "createDate DESC";
+	public static String ORDER_BY_DESC = "WikiPage.createDate DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"createDate"};
 

--- a/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageTitleComparator.java
+++ b/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageTitleComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.wiki.model.WikiPage;
  */
 public class PageTitleComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "title ASC";
+	public static String ORDER_BY_ASC = "WikiPage.title ASC";
 
-	public static String ORDER_BY_DESC = "title DESC";
+	public static String ORDER_BY_DESC = "WikiPage.title DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"title"};
 

--- a/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageVersionComparator.java
+++ b/portal-service/src/com/liferay/portlet/wiki/util/comparator/PageVersionComparator.java
@@ -22,9 +22,9 @@ import com.liferay.portlet.wiki.model.WikiPage;
  */
 public class PageVersionComparator extends OrderByComparator {
 
-	public static String ORDER_BY_ASC = "version ASC";
+	public static String ORDER_BY_ASC = "WikiPage.version ASC";
 
-	public static String ORDER_BY_DESC = "version DESC";
+	public static String ORDER_BY_DESC = "WikiPage.version DESC";
 
 	public static String[] ORDER_BY_FIELDS = {"version"};
 


### PR DESCRIPTION
All comparators has been modified to included table name for fields in ORDER BY clause except the following comparators:
- Group and Organization comparators in package "com.liferay.portal.util.comparator" because these use alias and this works fine.
- RepositoryModel comparators in package "com.liferay.portlet.documentlibrary.util.comparator" because these are used for several database tables. We have checked that this comparator is not used in queries with the preconditions to fail (see LPS-19613)
- BaseWorkflowTaskDueDateComparator file because it seems that WorkflowTask table doesn't exist neither in portal database  nor in external plugins
