### PR TITLE
LPS-19213 Actions button added to Document Library list display style

### DIFF
--- a/portal-web/docroot/html/portal/css/taglib/icon_menu.jspf
+++ b/portal-web/docroot/html/portal/css/taglib/icon_menu.jspf
@@ -166,6 +166,7 @@
 
 .lfr-actions li .taglib-text {
 	color: #34404F;
+	display: inline-block;
 }
 
 .lfr-menu-list li .taglib-icon img {


### PR DESCRIPTION
The span element needs 'display:inline-block' style for Chrome to be shown. It works for Firefox too.
