### PR TITLE
LPS-19936 Users & Organizations dropdown menus affect each other

### DIFF
--- a/portal-web/docroot/html/portlet/bookmarks/view.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view.jsp
@@ -110,7 +110,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 			</c:if>
 
 			<aui:column columnWidth="<%= 75 %>" cssClass="lfr-asset-column lfr-asset-column-details" first="<%= true %>">
-				<liferay-ui:panel-container extended="<%= false %>" persistState="<%= true %>">
+				<liferay-ui:panel-container extended="<%= false %>" id="bookmarkPanelContainer" persistState="<%= true %>">
 					<c:if test="<%= folder != null %>">
 						<div class="lfr-asset-description">
 							<%= HtmlUtil.escape(folder.getDescription()) %>
@@ -141,7 +141,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 					</c:if>
 
 					<c:if test="<%= foldersCount > 0 %>">
-						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title='<%= (folder != null) ? "subfolders" : "folders" %>'>
+						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="bookmarkFoldersPanel" persistState="<%= true %>" title='<%= (folder != null) ? "subfolders" : "folders" %>'>
 							<liferay-ui:search-container
 								curParam="cur1"
 								delta="<%= foldersPerPage %>"
@@ -174,7 +174,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 						</liferay-ui:panel>
 					</c:if>
 
-					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="bookmarks">
+					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="bookmarkEntriesPanel" persistState="<%= true %>" title="bookmarks">
 						<%@ include file="/html/portlet/bookmarks/view_entries.jspf" %>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>

--- a/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
@@ -560,7 +560,7 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 									}
 						%>
 
-									<liferay-ui:panel collapsible="<%= true %>" cssClass="metadata" extended="<%= true %>" persistState="<%= true %>" title="<%= ddmStructure.getName(LocaleUtil.getDefault()) %>">
+									<liferay-ui:panel collapsible="<%= true %>" cssClass="metadata" extended="<%= true %>" id="documentLibraryAssetMetadataPanel" persistState="<%= true %>" title="<%= ddmStructure.getName(LocaleUtil.getDefault()) %>">
 
 										<%= DDMXSDUtil.getHTML(pageContext, ddmStructure.getXsd(), fields, String.valueOf(ddmStructure.getPrimaryKey()), true, locale) %>
 
@@ -591,7 +591,7 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 									String name = "metadata." + ddmStructure.getName(LocaleUtil.getDefault(), true);
 						%>
 
-									<liferay-ui:panel collapsible="<%= true %>" cssClass="lfr-asset-metadata" persistState="<%= true %>" title="<%= name %>">
+									<liferay-ui:panel collapsible="<%= true %>" cssClass="lfr-asset-metadata" id="documentLibraryAssetAssetMetadataPanel" persistState="<%= true %>" title="<%= name %>">
 
 										<%= DDMXSDUtil.getHTML(pageContext, ddmStructure.getXsd(), fields, String.valueOf(ddmStructure.getPrimaryKey()), true, locale) %>
 
@@ -605,7 +605,7 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 						}
 						%>
 
-						<liferay-ui:panel collapsible="<%= true %>" cssClass="version-history" persistState="<%= true %>" title="version-history">
+						<liferay-ui:panel collapsible="<%= true %>" cssClass="version-history" id="documentLibraryAssetVersionHistoryPanel" persistState="<%= true %>" title="version-history">
 
 							<%
 							boolean comparableFileEntry = DocumentConversionUtil.isComparableVersion(extension);

--- a/portal-web/docroot/html/portlet/document_library/view_file_shortcut.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_shortcut.jsp
@@ -218,7 +218,7 @@ if (Validator.isNotNull(folder.getName())) {
 
 <div class="file-entry-panels">
 	<liferay-ui:panel-container extended="<%= false %>" id="documentLibraryDocumentPanelContainer" persistState="<%= true %>">
-		<liferay-ui:panel collapsible="<%= true %>" cssClass="version-history" extended="<%= true %>" persistState="<%= true %>" title="version-history">
+		<liferay-ui:panel collapsible="<%= true %>" cssClass="version-history" extended="<%= true %>" id="documentLibraryDocumentVersionHistoryPanel" persistState="<%= true %>" title="version-history">
 
 			<%
 			boolean showNonApprovedDocuments = false;
@@ -294,7 +294,7 @@ if (Validator.isNotNull(folder.getName())) {
 		</liferay-ui:panel>
 
 		<c:if test="<%= PropsValues.DL_FILE_ENTRY_COMMENTS_ENABLED %>">
-			<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="comments">
+			<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="documentLibraryDocumentCommentsPanel" persistState="<%= true %>" title="comments">
 				<portlet:actionURL var="discussionURL">
 					<portlet:param name="struts_action" value="/document_library/edit_file_entry_discussion" />
 				</portlet:actionURL>

--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -127,7 +127,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 			</c:if>
 
 			<aui:column columnWidth="<%= showFolderMenu ? 75 : 100 %>" cssClass="lfr-asset-column lfr-asset-column-details" first="<%= true %>">
-				<liferay-ui:panel-container extended="<%= false %>" persistState="<%= true %>">
+				<liferay-ui:panel-container extended="<%= false %>" id="docLibraryPanelContainer" persistState="<%= true %>">
 					<c:if test="<%= folder != null %>">
 						<c:if test="<%= Validator.isNotNull(folder.getDescription()) %>">
 							<div class="lfr-asset-description">
@@ -160,7 +160,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 					</c:if>
 
 					<c:if test="<%= foldersCount > 0 %>">
-						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title='<%= (folder != null) ? "subfolders" : "folders" %>'>
+						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="docLibraryFoldersPanel" persistState="<%= true %>" title='<%= (folder != null) ? "subfolders" : "folders" %>'>
 							<liferay-ui:search-container
 								curParam="cur1"
 								delta="<%= foldersPerPage %>"
@@ -193,7 +193,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 						</liferay-ui:panel>
 					</c:if>
 
-					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="documents">
+					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="docLibraryDocsPanel" persistState="<%= true %>" title="documents">
 						<%@ include file="/html/portlet/document_library_display/view_file_entries.jspf" %>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>

--- a/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
@@ -101,9 +101,9 @@ Map<String, ThemeSetting> configurableSettings = selTheme.getConfigurableSetting
 
 		<c:if test="<%= editable %>">
 			<c:if test="<%= !colorSchemes.isEmpty() || !configurableSettings.isEmpty() %>">
-				<liferay-ui:panel-container extended="<%= true %>" persistState="<%= true %>">
+				<liferay-ui:panel-container extended="<%= true %>" id="lookandfeelPanelContainer" persistState="<%= true %>">
 					<c:if test="<%= !colorSchemes.isEmpty() %>">
-						<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, "color-schemes-x", colorSchemes.size()) %>'>
+						<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" id="lookandfeelColoursPanel" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, "color-schemes-x", colorSchemes.size()) %>'>
 							<aui:fieldset cssCclass="color-schemes">
 								<div class="lfr-component lfr-theme-list">
 
@@ -134,7 +134,7 @@ Map<String, ThemeSetting> configurableSettings = selTheme.getConfigurableSetting
 					</c:if>
 
 					<c:if test="<%= !configurableSettings.isEmpty() %>">
-						<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title="settings">
+						<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" id="lookandfeelSettingsPanel" persistState="<%= true %>" title="settings">
 							<aui:fieldset>
 
 								<%

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -369,23 +369,23 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 					</c:otherwise>
 				</c:choose>
 
-				<liferay-ui:panel-container cssClass="export-pages-panel-container" extended="<%= true %>" persistState="<%= true %>">
-					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="pages">
+				<liferay-ui:panel-container cssClass="export-pages-panel-container" extended="<%= true %>" id="exportPagesPanelContainer" persistState="<%= true %>">
+					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="exportPagesPagesPanel" persistState="<%= true %>" title="pages">
 						<%@ include file="/html/portlet/layouts_admin/publish_layouts_select_pages.jspf" %>
 					</liferay-ui:panel>
 
-					<liferay-ui:panel collapsible="<%= true %>" defaultState="closed" extended="<%= true %>" persistState="<%= true %>" title="options">
+					<liferay-ui:panel collapsible="<%= true %>" defaultState="closed" extended="<%= true %>" id="exportPagesOptionsPanel" persistState="<%= true %>" title="options">
 						<%@ include file="/html/portlet/layouts_admin/publish_layouts_options.jspf" %>
 					</liferay-ui:panel>
 
 					<c:if test="<%= !localPublishing %>">
-						<liferay-ui:panel collapsible="<%= true %>" defaultState="closed" extended="<%= true %>" persistState="<%= true %>" title="remote-live-connection-settings">
+						<liferay-ui:panel collapsible="<%= true %>" defaultState="closed" extended="<%= true %>" id="exportPagesConnectionPanel" persistState="<%= true %>" title="remote-live-connection-settings">
 							<%@ include file="/html/portlet/layouts_admin/publish_layouts_remote_options.jspf" %>
 						</liferay-ui:panel>
 					</c:if>
 
 					<c:if test="<%= schedule %>">
-						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="schedule">
+						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="exportPagesSchedulePanel" persistState="<%= true %>" title="schedule">
 							<%@ include file="/html/portlet/layouts_admin/publish_layouts_scheduler.jspf" %>
 						</liferay-ui:panel>
 					</c:if>

--- a/portal-web/docroot/html/portlet/shopping/checkout_first.jsp
+++ b/portal-web/docroot/html/portlet/shopping/checkout_first.jsp
@@ -71,8 +71,8 @@ List addresses = AddressServiceUtil.getAddresses(Contact.class.getName(), contac
 
 	<aui:model-context bean="<%= order %>" model="<%= ShoppingOrder.class %>" />
 
-	<liferay-ui:panel-container extended="<%= true %>" persistState="<%= true %>">
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="billing-address">
+	<liferay-ui:panel-container extended="<%= true %>" id="checkoutPanelContainer" persistState="<%= true %>">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="checkoutBillingAddressPanel" persistState="<%= true %>" title="billing-address">
 			<liferay-ui:error exception="<%= BillingCityException.class %>" message="please-enter-a-valid-city" />
 			<liferay-ui:error exception="<%= BillingCountryException.class %>" message="please-enter-a-valid-country" />
 			<liferay-ui:error exception="<%= BillingEmailAddressException.class %>" message="please-enter-a-valid-email-address" />
@@ -147,7 +147,7 @@ List addresses = AddressServiceUtil.getAddresses(Contact.class.getName(), contac
 			</aui:fieldset>
 		</liferay-ui:panel>
 
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="shipping-address">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="checkoutShippingAddressPanel" persistState="<%= true %>" title="shipping-address">
 			<liferay-ui:error exception="<%= ShippingCityException.class %>" message="please-enter-a-valid-city" />
 			<liferay-ui:error exception="<%= ShippingCountryException.class %>" message="please-enter-a-valid-country" />
 			<liferay-ui:error exception="<%= ShippingEmailAddressException.class %>" message="please-enter-a-valid-email-address" />
@@ -230,7 +230,7 @@ List addresses = AddressServiceUtil.getAddresses(Contact.class.getName(), contac
 		%>
 
 		<c:if test="<%= !shoppingPrefs.usePayPal() && (ccTypes.length > 0) %>">
-			<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="credit-card">
+			<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="checkoutCreditCardPanel" persistState="<%= true %>" title="credit-card">
 				<liferay-ui:error exception="<%= CCExpirationException.class %>" message="please-enter-a-valid-credit-card-expiration-date" />
 				<liferay-ui:error exception="<%= CCNameException.class %>" message="please-enter-the-full-name-exactly-as-it-is-appears-on-your-credit-card" />
 				<liferay-ui:error exception="<%= CCNumberException.class %>" message="please-enter-a-valid-credit-card-number" />
@@ -311,7 +311,7 @@ List addresses = AddressServiceUtil.getAddresses(Contact.class.getName(), contac
 			</liferay-ui:panel>
 		</c:if>
 
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="comments">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="checkoutCommentsPanel" persistState="<%= true %>" title="comments">
 			<aui:fieldset>
 				<aui:input label="" name="comments" />
 			</aui:fieldset>

--- a/portal-web/docroot/html/portlet/shopping/edit_coupon.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_coupon.jsp
@@ -103,8 +103,8 @@ String discountType = BeanParamUtil.getString(coupon, request, "discountType");
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
 
-	<liferay-ui:panel-container extended="<%= true %>" persistState="<%= true %>">
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="discount">
+	<liferay-ui:panel-container extended="<%= true %>" id="editCouponPanelContainer" persistState="<%= true %>">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="editCouponDiscountPanel" persistState="<%= true %>" title="discount">
 			<liferay-ui:message arguments="<%= currencyFormat.format(0) %>" key="coupons-can-be-set-to-only-apply-to-orders-above-a-minimum-amount" translateArguments="<%= false %>" />
 
 			<br /><br />
@@ -135,7 +135,7 @@ String discountType = BeanParamUtil.getString(coupon, request, "discountType");
 			</aui:fieldset>
 		</liferay-ui:panel>
 
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="limits">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="editCouponLimitsPanel" persistState="<%= true %>" title="limits">
 			<liferay-ui:error exception="<%= CouponLimitCategoriesException.class %>">
 
 				<%

--- a/portal-web/docroot/html/portlet/shopping/edit_item.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_item.jsp
@@ -175,8 +175,8 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
 
-	<liferay-ui:panel-container extended="<%= true %>" persistState="<%= true %>">
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="fields">
+	<liferay-ui:panel-container extended="<%= true %>" id="editItemPanelContainer" persistState="<%= true %>">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="editItemFieldsPanel"  persistState="<%= true %>" title="fields">
 			<aui:input name="fields" type="hidden" />
 
 			<liferay-ui:message key="fields-are-added-if-you-need-to-distinguish-items-based-on-criteria-chosen-by-the-user" />
@@ -256,7 +256,7 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 
 		</liferay-ui:panel>
 
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="prices">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>"  id="editItemPricesPanel"  persistState="<%= true %>" title="prices">
 			<aui:input name="prices" type="hidden" />
 
 			<aui:fieldset>
@@ -426,7 +426,7 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 			<aui:button onClick='<%= renderResponse.getNamespace() + "addPrice();" %>' value="add-price" />
 		</liferay-ui:panel>
 
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="images">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>"  id="editItemImagesPanel" persistState="<%= true %>" title="images">
 			<liferay-ui:error exception="<%= ItemLargeImageNameException.class %>">
 
 				<%

--- a/portal-web/docroot/html/portlet/shopping/edit_order.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_order.jsp
@@ -575,8 +575,8 @@ long orderId = BeanParamUtil.getLong(order, request, "orderId");
 </aui:form>
 
 <c:if test="<%= !windowState.equals(LiferayWindowState.POP_UP) %>">
-	<liferay-ui:panel-container extended="<%= true %>" persistState="<%= true %>">
-		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title="comments">
+	<liferay-ui:panel-container extended="<%= true %>"  id="editOrderPanelContainer" persistState="<%= true %>">
+		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="editOrderCommentsPanel" persistState="<%= true %>" title="comments">
 			<portlet:actionURL var="discussionURL">
 				<portlet:param name="struts_action" value="/shopping/edit_order_discussion" />
 			</portlet:actionURL>

--- a/portal-web/docroot/html/portlet/users_admin/view_tree.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/view_tree.jspf
@@ -267,7 +267,7 @@ int organizationsCount = OrganizationLocalServiceUtil.searchCount(company.getCom
 	</liferay-util:buffer>
 
 	<aui:column columnWidth="<%= (organization != null) ? 75 : 100 %>" cssClass="lfr-asset-column lfr-asset-column-details" first="<%= true %>">
-		<liferay-ui:panel-container extended="<%= false %>" persistState="<%= true %>">
+		<liferay-ui:panel-container extended="<%= false %>" id="organizationPanelContainer" persistState="<%= true %>">
 			<%= organizationInfo %>
 
 			<%
@@ -300,13 +300,13 @@ int organizationsCount = OrganizationLocalServiceUtil.searchCount(company.getCom
 			%>
 
 			<c:if test="<%= showOrganizations %>">
-				<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title='<%= (organization == null) ? "organizations" : (organizationsCount == 1) ? LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(organizationsCount)) : LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(organizationsCount)) %>'>
+				<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="organizationOrgsPanel" persistState="<%= true %>" title='<%= (organization == null) ? "organizations" : (organizationsCount == 1) ? LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(organizationsCount)) : LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(organizationsCount)) %>'>
 					<%= organizationsTree %>
 				</liferay-ui:panel>
 			</c:if>
 
 			<c:if test="<%= showUsers %>">
-				<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" persistState="<%= true %>" title='<%= (organization == null) ? "users" : (usersCount == 1) ? LanguageUtil.format(pageContext, "x-user", String.valueOf(usersCount)) : LanguageUtil.format(pageContext, "x-users", String.valueOf(usersCount)) %>'>
+				<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="organizationUsersPanel" persistState="<%= true %>" title='<%= (organization == null) ? "users" : (usersCount == 1) ? LanguageUtil.format(pageContext, "x-user", String.valueOf(usersCount)) : LanguageUtil.format(pageContext, "x-users", String.valueOf(usersCount)) %>'>
 
 					<%
 					boolean organizationContextView = true;


### PR DESCRIPTION
When you use a ui:panel-container and two or more ui:panel inside it and you don't specify an id for them, HTML generated contains the same id  for all children ui:panel. This causes the incorrect behavior.
