### PR TITLE
LPS-19057 Permissions UI

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -177,10 +177,18 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			addGuestPermissions = true;
 		}
 
+		boolean addGroupPermissions =  true;
+
+		Group group = groupLocalService.getGroup(groupId);
+
+		if (privateLayout && group.isUser()) {
+			addGroupPermissions = false;
+		}
+
 		resourceLocalService.addResources(
 			user.getCompanyId(), groupId, user.getUserId(),
-			Layout.class.getName(), layout.getPlid(), false, true,
-			addGuestPermissions);
+			Layout.class.getName(), layout.getPlid(), false,
+			addGroupPermissions, addGuestPermissions);
 
 		// Group
 


### PR DESCRIPTION
LPS-19057 Permissions UI incorrectly reports that the Power User role is able to perform ADD_DISCUSSION and VIEW for private pages in a personal community
