### PR TITLE
LPS-24380

### DIFF
--- a/portal-web/docroot/html/themes/_unstyled/templates/init.ftl
+++ b/portal-web/docroot/html/themes/_unstyled/templates/init.ftl
@@ -293,7 +293,9 @@
 	<#assign the_title = page_group.getDescriptiveName() />
 </#if>
 
-<#assign the_title = htmlUtil.escape(the_title) />
+<#if (tilesTitle == "")>
+	<#assign the_title = htmlUtil.escape(the_title) />
+</#if>
 
 <#if layouts??>
 	<#assign pages = layouts />

--- a/portal-web/docroot/html/themes/_unstyled/templates/init.vm
+++ b/portal-web/docroot/html/themes/_unstyled/templates/init.vm
@@ -287,7 +287,9 @@
 	#set ($the_title = $page_group.getDescriptiveName())
 #end
 
-#set ($the_title = $htmlUtil.escape($the_title))
+#if ($tilesTitle == "")
+	#set ($the_title = $htmlUtil.escape($the_title))
+#end
 
 #if ($layouts)
 	#set ($pages = $layouts)


### PR DESCRIPTION
Portlet title is only escaped when tiles-def's title is empty
