### PR TITLE
LPS-20784: Warning in console when built-in site/page templates selected

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandlerImpl.java
@@ -124,8 +124,8 @@ public class JournalContentPortletDataHandlerImpl
 		String articleId = portletPreferences.getValue("articleId", null);
 
 		if (articleId == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
+			if (_log.isDebugEnabled()) {
+				_log.debug(
 					"No article id found in preferences of portlet " +
 						portletId);
 			}


### PR DESCRIPTION
Hi Juan,
I had yesterday a conversation with Jorge about this task and for now the best option is to just change warning message to debug message for now. This whole exporting algorithm should go through revision according to Jorge. In the past(starting with version 5.0 or 5.1) only option to export content that was not displayed through any journal content was to actually create a hidden portlet, assign the content to the created hidden portlet and then export the whole structure. This is the reason why at the beggining of exporting algorithm there is a call to getAlwaysExportablePortlets method. Today it is not case anymore, but Jorge is not sure 100% are there any circumstances under which that part of logic around always exportable portlets still needs to coexist. So for now this should be temporary solution till revision.

Best Regards
