### PR TITLE
LPS-25749 Social Activity - activity counter id breaks when adding a new activity counter in a new period

### DIFF
--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalService.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalService.java
@@ -244,6 +244,13 @@ public interface SocialActivityCounterLocalService
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	public com.liferay.portlet.social.model.SocialActivityCounter addActivityCounter(
+		long groupId, long classNameId, long classPK, java.lang.String name,
+		int ownerType, int currentValue, int totalValue, int startPeriod,
+		int endPeriod, long previousActivityCounterId, int periodLength)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	public void addActivityCounters(
 		com.liferay.portlet.social.model.SocialActivity activity)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -252,7 +259,7 @@ public interface SocialActivityCounterLocalService
 	public com.liferay.portlet.social.model.SocialActivityCounter createActivityCounter(
 		long groupId, long classNameId, long classPK, java.lang.String name,
 		int ownerType, int currentValue, int totalValue, int startPeriod,
-		int endPeriod)
+		int endPeriod, long previousActivityCounterId, int periodLength)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalServiceUtil.java
@@ -273,6 +273,18 @@ public class SocialActivityCounterLocalServiceUtil {
 			ownerType, currentValue, totalValue, startPeriod, endPeriod);
 	}
 
+	public static com.liferay.portlet.social.model.SocialActivityCounter addActivityCounter(
+		long groupId, long classNameId, long classPK, java.lang.String name,
+		int ownerType, int currentValue, int totalValue, int startPeriod,
+		int endPeriod, long previousActivityCounterId, int periodLength)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addActivityCounter(groupId, classNameId, classPK, name,
+			ownerType, currentValue, totalValue, startPeriod, endPeriod,
+			previousActivityCounterId, periodLength);
+	}
+
 	public static void addActivityCounters(
 		com.liferay.portlet.social.model.SocialActivity activity)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -283,12 +295,13 @@ public class SocialActivityCounterLocalServiceUtil {
 	public static com.liferay.portlet.social.model.SocialActivityCounter createActivityCounter(
 		long groupId, long classNameId, long classPK, java.lang.String name,
 		int ownerType, int currentValue, int totalValue, int startPeriod,
-		int endPeriod)
+		int endPeriod, long previousActivityCounterId, int periodLength)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .createActivityCounter(groupId, classNameId, classPK, name,
-			ownerType, currentValue, totalValue, startPeriod, endPeriod);
+			ownerType, currentValue, totalValue, startPeriod, endPeriod,
+			previousActivityCounterId, periodLength);
 	}
 
 	public static void deleteActivityCounters(

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityCounterLocalServiceWrapper.java
@@ -270,6 +270,17 @@ public class SocialActivityCounterLocalServiceWrapper
 			startPeriod, endPeriod);
 	}
 
+	public com.liferay.portlet.social.model.SocialActivityCounter addActivityCounter(
+		long groupId, long classNameId, long classPK, java.lang.String name,
+		int ownerType, int currentValue, int totalValue, int startPeriod,
+		int endPeriod, long previousActivityCounterId, int periodLength)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _socialActivityCounterLocalService.addActivityCounter(groupId,
+			classNameId, classPK, name, ownerType, currentValue, totalValue,
+			startPeriod, endPeriod, previousActivityCounterId, periodLength);
+	}
+
 	public void addActivityCounters(
 		com.liferay.portlet.social.model.SocialActivity activity)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -280,12 +291,12 @@ public class SocialActivityCounterLocalServiceWrapper
 	public com.liferay.portlet.social.model.SocialActivityCounter createActivityCounter(
 		long groupId, long classNameId, long classPK, java.lang.String name,
 		int ownerType, int currentValue, int totalValue, int startPeriod,
-		int endPeriod)
+		int endPeriod, long previousActivityCounterId, int periodLength)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _socialActivityCounterLocalService.createActivityCounter(groupId,
 			classNameId, classPK, name, ownerType, currentValue, totalValue,
-			startPeriod, endPeriod);
+			startPeriod, endPeriod, previousActivityCounterId, periodLength);
 	}
 
 	public void deleteActivityCounters(


### PR DESCRIPTION
Hi Juan, 

As per Jorge's request I'm forwarding this to you.

Remarks:
I created a new method to preserve the old one too, because the 7cogs hook calls that method and it doesn't need to close old periods, so no need to go the new way...

Zs.
