### PR TITLE
LPS-26212 Wiki - Add Page takes the user to edit page of previously selected page

### DIFF
--- a/portal-web/docroot/html/portlet/wiki/page_iterator.jsp
+++ b/portal-web/docroot/html/portlet/wiki/page_iterator.jsp
@@ -359,9 +359,12 @@ for (int i = 0; i < results.size(); i++) {
 			<portlet:param name="struts_action" value="/wiki/edit_page" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />
 			<portlet:param name="nodeId" value="<%= String.valueOf(node.getNodeId()) %>" />
-			<portlet:param name="title" value="<%= StringPool.BLANK %>" />
 			<portlet:param name="editTitle" value="1" />
 		</portlet:actionURL>
+
+		<%
+			addPageURL = HttpUtil.setParameter(addPageURL, "title", StringPool.BLANK);
+		%>
 
 		<aui:button href="<%= addPageURL %>" name="addPageButton" value="add-page" />
 	</aui:button-row>


### PR DESCRIPTION
The source code for the Add Page button at /wiki/page_iterator.jsp uses portlet:actionURL tag-lib to generate the actionURL. 

To make sure that the parameter "title" is cleared, the portlet:param name="title" in the portlet:actionURL tag-lib is set to StringPool.BLANK. This code was introduced to solve ticket LPS-5252. However, at version 6.2.X, if the public render parameter "title" has already been set (for example, by viewing an existing wiki Page), this value is used even if it was set to BLANK in the actionURL of the Add Page button. Therefore, when clicking Add Page the edit_page.jsp displays the edit form of the latest visited wiki Page, instead of the add new page form.

The root of this issue lies in how the actionURL tag-lib processes blank parameters. Instead of adding the key plus an empty value (e.g. &title=), it removes the parameter from the URL (See method addParam at ParamAndPropertyAncestorTagImpl.java). For the wiki Pages, since the title parameter is not overwritten with an empty value from the URL, the current value of the public render parameter "title" is used.

As a conclusion, there are two possible solutions for ticket LPS-26212:
1. Setting the value of the title param in the actionURL of the Add Page button to BLANK by using addPageURL.setParameter(...)
2. Changing actionURL tag-lib so that BLANK parameters are accepted for those cases in which public render parameters are to be ignored.

Since solution 2 may have an impact in many other portlets and the only case found (so far) is the title public render parameter (which is only used at Wiki portlet), solution 1 was commited instead. 
