### PR TITLE
LPS-26495 API improvements for backend Localization 

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutModelImpl.java
@@ -16,7 +16,6 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -451,13 +450,8 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -541,13 +535,8 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -634,13 +623,9 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -725,13 +710,9 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String keywords = keywordsMap.get(locale);
-
-			setKeywords(keywords, locale, defaultLocale);
-		}
+		setKeywords(LocalizationUtil.updateLocalizationXmlFromMap(keywordsMap,
+				getKeywords(), "Keywords",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -815,13 +796,8 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String robots = robotsMap.get(locale);
-
-			setRobots(robots, locale, defaultLocale);
-		}
+		setRobots(LocalizationUtil.updateLocalizationXmlFromMap(robotsMap,
+				getRobots(), "Robots", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutPrototypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutPrototypeModelImpl.java
@@ -16,7 +16,6 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -291,13 +290,8 @@ public class LayoutPrototypeModelImpl extends BaseModelImpl<LayoutPrototype>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portal.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -509,13 +508,8 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -599,13 +593,8 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -692,13 +681,9 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -783,13 +768,9 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String keywords = keywordsMap.get(locale);
-
-			setKeywords(keywords, locale, defaultLocale);
-		}
+		setKeywords(LocalizationUtil.updateLocalizationXmlFromMap(keywordsMap,
+				getKeywords(), "Keywords",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -873,13 +854,8 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String robots = robotsMap.get(locale);
-
-			setRobots(robots, locale, defaultLocale);
-		}
+		setRobots(LocalizationUtil.updateLocalizationXmlFromMap(robotsMap,
+				getRobots(), "Robots", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetPrototypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetPrototypeModelImpl.java
@@ -16,7 +16,6 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -314,13 +313,8 @@ public class LayoutSetPrototypeModelImpl extends BaseModelImpl<LayoutSetPrototyp
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portal/model/impl/RoleModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RoleModelImpl.java
@@ -16,7 +16,6 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -377,13 +376,8 @@ public class RoleModelImpl extends BaseModelImpl<Role> implements RoleModel {
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -470,13 +464,9 @@ public class RoleModelImpl extends BaseModelImpl<Role> implements RoleModel {
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
@@ -528,13 +528,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 					return;
 				}
 
-				Locale[] locales = LanguageUtil.getAvailableLocales();
-
-				for (Locale locale : locales) {
-					String ${column.name} = ${column.name}Map.get(locale);
-
-					set${column.methodName}(${column.name}, locale, defaultLocale);
-				}
+				set${column.methodName}(LocalizationUtil.updateLocalizationXmlFromMap(${column.name}Map, get${column.methodName}(), "${column.methodName}", LocaleUtil.toLanguageId(defaultLocale)));
 			}
 		</#if>
 

--- a/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
@@ -725,6 +725,28 @@ public class LocalizationImpl implements Localization {
 		return xml;
 	}
 
+	public String updateLocalizationXmlFromMap(
+		Map<Locale, String> localizationMap, String xml, String key,
+		String defaultLanguageId) {
+
+		Locale[] locales = LanguageUtil.getAvailableLocales();
+
+		for (Locale locale : locales) {
+			String value = localizationMap.get(locale);
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			if (Validator.isNotNull(value)) {
+				xml = updateLocalization(
+					xml, key, value, languageId, defaultLanguageId);
+			}
+			else {
+				xml = removeLocalization(xml, key, languageId);
+			}
+		}
+
+		return xml;
+	}
+
 	private void _copyNonExempt(
 			XMLStreamReader xmlStreamReader, XMLStreamWriter xmlStreamWriter,
 			String exemptLanguageId, String defaultLanguageId, boolean cdata)

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.asset.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -447,13 +446,8 @@ public class AssetCategoryModelImpl extends BaseModelImpl<AssetCategory>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -540,13 +534,9 @@ public class AssetCategoryModelImpl extends BaseModelImpl<AssetCategory>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.asset.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -594,13 +593,8 @@ public class AssetEntryModelImpl extends BaseModelImpl<AssetEntry>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -687,13 +681,9 @@ public class AssetEntryModelImpl extends BaseModelImpl<AssetEntry>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -778,13 +768,8 @@ public class AssetEntryModelImpl extends BaseModelImpl<AssetEntry>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String summary = summaryMap.get(locale);
-
-			setSummary(summary, locale, defaultLocale);
-		}
+		setSummary(LocalizationUtil.updateLocalizationXmlFromMap(summaryMap,
+				getSummary(), "Summary", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.asset.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -402,13 +401,8 @@ public class AssetVocabularyModelImpl extends BaseModelImpl<AssetVocabulary>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -495,13 +489,9 @@ public class AssetVocabularyModelImpl extends BaseModelImpl<AssetVocabulary>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordSetModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordSetModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.dynamicdatalists.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -399,13 +398,8 @@ public class DDLRecordSetModelImpl extends BaseModelImpl<DDLRecordSet>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -492,13 +486,9 @@ public class DDLRecordSetModelImpl extends BaseModelImpl<DDLRecordSet>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMContentModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMContentModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.dynamicdatamapping.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -318,13 +317,8 @@ public class DDMContentModelImpl extends BaseModelImpl<DDMContent>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	public String getDescription() {

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.dynamicdatamapping.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -440,13 +439,8 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	public String getOriginalName() {
@@ -543,13 +537,9 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	public String getOriginalDescription() {

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMTemplateModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMTemplateModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.dynamicdatamapping.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -392,13 +391,8 @@ public class DDMTemplateModelImpl extends BaseModelImpl<DDMTemplate>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -485,13 +479,9 @@ public class DDMTemplateModelImpl extends BaseModelImpl<DDMTemplate>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.journal.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -558,13 +557,8 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -675,13 +669,9 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalStructureModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalStructureModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.journal.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -416,13 +415,8 @@ public class JournalStructureModelImpl extends BaseModelImpl<JournalStructure>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -509,13 +503,9 @@ public class JournalStructureModelImpl extends BaseModelImpl<JournalStructure>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalTemplateModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalTemplateModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.journal.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -427,13 +426,8 @@ public class JournalTemplateModelImpl extends BaseModelImpl<JournalTemplate>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -520,13 +514,9 @@ public class JournalTemplateModelImpl extends BaseModelImpl<JournalTemplate>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRActionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRActionModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.mobiledevicerules.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -425,13 +424,8 @@ public class MDRActionModelImpl extends BaseModelImpl<MDRAction>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -518,13 +512,9 @@ public class MDRActionModelImpl extends BaseModelImpl<MDRAction>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.mobiledevicerules.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -357,13 +356,8 @@ public class MDRRuleGroupModelImpl extends BaseModelImpl<MDRRuleGroup>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -450,13 +444,9 @@ public class MDRRuleGroupModelImpl extends BaseModelImpl<MDRRuleGroup>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	public long getColumnBitmask() {

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.mobiledevicerules.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -385,13 +384,8 @@ public class MDRRuleModelImpl extends BaseModelImpl<MDRRule>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String name = nameMap.get(locale);
-
-			setName(name, locale, defaultLocale);
-		}
+		setName(LocalizationUtil.updateLocalizationXmlFromMap(nameMap,
+				getName(), "Name", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -478,13 +472,9 @@ public class MDRRuleModelImpl extends BaseModelImpl<MDRRule>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsChoiceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsChoiceModelImpl.java
@@ -16,7 +16,6 @@ package com.liferay.portlet.polls.model.impl;
 
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -316,13 +315,9 @@ public class PollsChoiceModelImpl extends BaseModelImpl<PollsChoice>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	public long getColumnBitmask() {

--- a/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsQuestionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsQuestionModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.polls.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -366,13 +365,8 @@ public class PollsQuestionModelImpl extends BaseModelImpl<PollsQuestion>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String title = titleMap.get(locale);
-
-			setTitle(title, locale, defaultLocale);
-		}
+		setTitle(LocalizationUtil.updateLocalizationXmlFromMap(titleMap,
+				getTitle(), "Title", LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -459,13 +453,9 @@ public class PollsQuestionModelImpl extends BaseModelImpl<PollsQuestion>
 			return;
 		}
 
-		Locale[] locales = LanguageUtil.getAvailableLocales();
-
-		for (Locale locale : locales) {
-			String description = descriptionMap.get(locale);
-
-			setDescription(description, locale, defaultLocale);
-		}
+		setDescription(LocalizationUtil.updateLocalizationXmlFromMap(
+				descriptionMap, getDescription(), "Description",
+				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON

--- a/portal-impl/test/integration/com/liferay/portal/util/LocalizationImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/LocalizationImplTest.java
@@ -21,7 +21,9 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portlet.PortletPreferencesImpl;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 
@@ -170,6 +172,35 @@ public class LocalizationImplTest {
 			_germanHello,
 			LocalizationUtil.getPreferencesValue(
 				preferences, "greeting", _germanId));
+	}
+
+	@Test
+	public void testUpdateLocalizationXmlFromMap() {
+		Map<Locale, String>localizationMap = new HashMap<Locale, String>();
+		localizationMap.put(_english, _englishHello);
+
+		StringBundler sb = new StringBundler();
+		sb.append("<?xml version='1.0' encoding='UTF-8'?>");
+		sb.append("<root available-locales=\"en_US,de_DE\" ");
+		sb.append("default-locale=\"en_US\">");
+		sb.append("<greeting language-id=\"de_DE\">");
+		sb.append("<![CDATA[Beispiel auf Deutschl]]>");
+		sb.append("</greeting>");
+		sb.append("<greeting language-id=\"en_US\">");
+		sb.append("<![CDATA[Example in English]]>");
+		sb.append("</greeting>");
+		sb.append("</root>");
+
+		String xml = LocalizationUtil.updateLocalizationXmlFromMap(
+			localizationMap, sb.toString(), "greeting",
+			LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+		Assert.assertEquals(
+			_englishHello, LocalizationUtil.getLocalization(
+				xml, _englishId, false));
+		Assert.assertEquals(
+			StringPool.BLANK, LocalizationUtil.getLocalization(
+				xml, _germanId, false));
 	}
 
 	private Locale _english;

--- a/portal-service/src/com/liferay/portal/kernel/util/Localization.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Localization.java
@@ -397,4 +397,19 @@ public interface Localization {
 		String xml, String key, String value, String requestedLanguageId,
 		String defaultLanguageId, boolean cdata, boolean localized);
 
+	/**
+	 * Updates the localized string for the all the available languages in the
+	 * localizations XML for the map of locales and localized strings and changes the
+	 * default language. Stores the localized strings as characters in the XML.
+	 *
+	 * @param  localizationMap the locales and localized strings
+	 * @param  xml the localizations XML
+	 * @param  key the name of the localized string, such as &quot;Title&quot;
+	 * @param  defaultLanguageId the ID of the default language
+	 * @return the updated localizations XML
+	 */
+	public String updateLocalizationXmlFromMap(
+		Map<Locale, String> localizationMap, String xml, String key,
+		String defaultLanguageId);
+
 }

--- a/portal-service/src/com/liferay/portal/kernel/util/LocalizationUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/LocalizationUtil.java
@@ -249,6 +249,14 @@ public class LocalizationUtil {
 			localized);
 	}
 
+	public static String updateLocalizationXmlFromMap(
+		Map<Locale, String> localizationMap, String xml, String key,
+		String defaultLanguageId) {
+
+		return getLocalization().updateLocalizationXmlFromMap(
+			localizationMap, xml, key, defaultLanguageId);
+	}
+
 	public void setLocalization(Localization localization) {
 		_localization = localization;
 	}


### PR DESCRIPTION
The code to update the xml of the localized entity fields from a Map<Locale, String> are centralized at a new method in the LocalizationUtil class. 

This change simplifies the code of the *ModelImpl class of the services and allows updating a localization xml from a Map outside the services, which is required to solve issue LPS-26295.

The Pull-Request includes:
- The modification of the LocalizationUtil API (all classes)
- The corresponding unitary test, extending LocalizationImplTest
- A modification at the template of the ModelImpl service classes, so that the new central method is used.
- The regenerated code of the ModelImpl of the affected services (those with localized fields)
