### PR TITLE
LPS-25224

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -33,6 +33,7 @@ import com.liferay.portal.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.service.ReleaseLocalServiceUtil;
 import com.liferay.portal.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.util.InitUtil;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.sql.Connection;
@@ -208,9 +209,11 @@ public class DBUpgrader {
 
 		// Update indexes
 
-		if (StartupHelperUtil.isUpgraded()) {
-			StartupHelperUtil.updateIndexes();
+		if (PropsValues.VERIFY_DROP_UNUSED_INDEXES) {
+			StartupHelperUtil.setDropIndexes(true);
 		}
+
+		StartupHelperUtil.updateIndexes();
 
 		// Update release
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1574,6 +1574,8 @@ public class PropsValues {
 
 	public static final int VALUE_OBJECT_FINDER_THREAD_LOCAL_CACHE_MAX_SIZE = GetterUtil.getInteger(PropsUtil.get(PropsKeys.VALUE_OBJECT_FINDER_THREAD_LOCAL_CACHE_MAX_SIZE));
 
+	public static final boolean VERIFY_DROP_UNUSED_INDEXES = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.VERIFY_DROP_UNUSED_INDEXES));
+
 	public static final String[] VELOCITY_ENGINE_RESOURCE_LISTENERS = PropsUtil.getArray(PropsKeys.VELOCITY_ENGINE_RESOURCE_LISTENERS);
 
 	public static final boolean VELOCITY_ENGINE_RESOURCE_MANAGER_CACHE_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.VELOCITY_ENGINE_RESOURCE_MANAGER_CACHE_ENABLED));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -194,7 +194,7 @@
     # a patch what used a database index has been removed,
     # the database index remain in the database.
     #
-    verify.drop.unused.indexes=true
+    verify.drop.unused.indexes=false
 
 ##
 ## Convert

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -188,6 +188,14 @@
     #
     verify.frequency=1
 
+    #
+    # Specify if you want to drop unused database indexes during startup.
+    # One example of an unused index is when during patching,
+    # a patch what used a database index has been removed,
+    # the database index remain in the database.
+    #
+    verify.drop.unused.indexes=true
+
 ##
 ## Convert
 ##

--- a/portal-impl/test/integration/com/liferay/portal/dao/db/BaseDBTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/dao/db/BaseDBTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.db;
+
+import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.ExecutionTestListeners;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+
+import java.io.IOException;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Daniel Kocsis
+ */
+@ExecutionTestListeners(listeners = {EnvironmentExecutionTestListener.class})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+public class BaseDBTest {
+
+	@Test
+	public void testIsPortalIndex() throws IOException, SQLException {
+		Thread currentThread = Thread.currentThread();
+
+		BaseDB baseDB = (BaseDB) DBFactoryUtil.getDB();
+
+		Connection connection = null;
+
+		try {
+			connection = DataAccess.getConnection();
+
+			boolean result = baseDB.isPortalIndex(
+				connection, "IX_1E9D371D", true, "AssetEntry");
+
+			Assert.assertTrue(result);
+
+			result = baseDB.isPortalIndex(
+				connection, "IX_FC1F9C7B", false, "AssetEntry");
+
+			Assert.assertTrue(result);
+
+			result = baseDB.isPortalIndex(
+				connection, "IX_TEST_NON_PORTAL", true, "AssetEntry");
+
+			Assert.assertFalse(result);
+		}
+		finally {
+			DataAccess.cleanUp(connection);
+		}
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/dao/db/BaseDBTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/dao/db/BaseDBTest.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 /**
  * @author Daniel Kocsis
@@ -59,6 +60,12 @@ public class BaseDBTest {
 
 			result = baseDB.isPortalIndex(
 				connection, "IX_TEST_NON_PORTAL", true, "AssetEntry");
+
+			Assert.assertFalse(result);
+
+			result = baseDB.isPortalIndex(
+				connection, Mockito.anyString(), Mockito.anyBoolean(),
+				Mockito.anyString());
 
 			Assert.assertFalse(result);
 		}

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2159,6 +2159,8 @@ public interface PropsKeys {
 
 	public static final String VELOCITY_ENGINE_VELOCIMACRO_LIBRARY = "velocity.engine.velocimacro.library";
 
+	public static final String VERIFY_DROP_UNUSED_INDEXES = "verify.drop.unused.indexes";
+
 	public static final String VERIFY_FREQUENCY = "verify.frequency";
 
 	public static final String VERIFY_PROCESSES = "verify.processes";


### PR DESCRIPTION
Hi Juan,

This pull request is a slight refactor for the database index creation/dropping during the portal start up.

The idea behind this change is that the patching tool sometimes adds or removes patches which contain some new database indexes, or when we are deleting a patch an index should be dropped. But in order to know what index should we drop we should validate that it hasn't been added by the user.

I'm cc-ing Zsolt Balogh (@zsoltbalogh) since he is the responsible for the patching tool.

Thanks,

Máté
