### PR TITLE
[TECHNICAL SUPPORT] LPS-26833 Try to view a portlet when user has no view permission on that

### DIFF
--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -857,7 +857,11 @@ if ((layout.isTypePanel() || layout.isTypeControlPanel()) && !portletDisplay.get
 			if (!access || portletException) {
 				PortletRequestProcessor portletReqProcessor = (PortletRequestProcessor)portletCtx.getAttribute(WebKeys.PORTLET_STRUTS_PROCESSOR);
 
-				ActionMapping actionMapping = portletReqProcessor.processMapping(request, response, (String)portlet.getInitParams().get("view-action"));
+				ActionMapping actionMapping = null;
+
+				if (portletReqProcessor != null){
+					actionMapping = portletReqProcessor.processMapping(request, response, (String)portlet.getInitParams().get("view-action"));
+				}
 
 				ComponentDefinition definition = null;
 


### PR DESCRIPTION
Hi Juan,

This LPS is related to a customer issue, but solves not exactly the same problem that the customer reported. In 6.1 when you try to invoke a portlet via URL with exclusive mode it is possible to see its content without having view permission for that. In trunk an LPS fixed that but the error message that you can see in this case is not valid when you have not bundled portlets on the page. This fix solves the NPE and shows the same error message as you can see in case of bundled portlets.

Thanks,
Daniel
