### PR TITLE
[TECHNICAL SUPPORT] LPS-26414

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portlet.asset.NoSuchEntryException;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetLink;
 import com.liferay.portlet.asset.model.AssetLinkConstants;
+import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileShortcut;
@@ -229,6 +230,8 @@ public class DLAppHelperLocalServiceImpl
 			trashEntryLocalService.deleteEntry(
 				DLFileEntryConstants.getClassName(),
 				fileVersion.getFileVersionId());
+		}
+		catch (NoSuchFileVersionException nsfve) {
 		}
 		catch (com.liferay.portlet.trash.NoSuchEntryException nsee) {
 		}

--- a/portal-impl/test/integration/com/liferay/portal/util/BaseJsonClientTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/BaseJsonClientTestCase.java
@@ -161,21 +161,26 @@ public class BaseJsonClientTestCase {
 
 		beginIndex += variable.length() + 1;
 
+		int endIndex = -1;
+
 		if (string) {
 			beginIndex++;
 
-			int endIndex = responseContent.indexOf("\",", beginIndex);
+			endIndex = responseContent.indexOf("\",", beginIndex);
 
 			if (endIndex == -1) {
 				endIndex = responseContent.length() - 2;
 			}
-
-			return responseContent.substring(beginIndex, endIndex);
 		}
 		else {
-			return responseContent.substring(
-				beginIndex, responseContent.indexOf(",", beginIndex));
+			endIndex = responseContent.indexOf(",", beginIndex);
+
+			if (endIndex == -1) {
+				endIndex = responseContent.length() - 1;
+			}
 		}
+
+		return responseContent.substring(beginIndex, endIndex);
 	}
 
 	private class StringHandler implements ResponseHandler<String> {
@@ -191,9 +196,7 @@ public class BaseJsonClientTestCase {
 				return null;
 			}
 
-			String responseContent = EntityUtils.toString(httpEntity);
-
-			return responseContent;
+			return EntityUtils.toString(httpEntity);
 		}
 
 		protected void checkStatusCode(StatusLine statusLine)

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryExtensionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryExtensionTest.java
@@ -185,20 +185,55 @@ import org.junit.runner.RunWith;
 public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 
 	@Test
-	public void testAddFileEntryBasic() throws Exception {
+	public void testAddFileEntryBasic01() throws Exception {
 		testAddFileEntryBasic(_FILE_NAME, "Test.pdf", "txt", "Test.pdf.txt");
+	}
+
+	@Test
+	public void testAddFileEntryBasic02() throws Exception {
 		testAddFileEntryBasic(_FILE_NAME, _FILE_NAME, "txt", _FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic03() throws Exception {
 		testAddFileEntryBasic(
 			_FILE_NAME, _STRIPPED_FILE_NAME, "txt", _FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic04() throws Exception {
 		testAddFileEntryBasic(_FILE_NAME, "", "txt", _FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic05() throws Exception {
 		testAddFileEntryBasic(
 			_STRIPPED_FILE_NAME, _FILE_NAME, "txt", _FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic06() throws Exception {
 		testAddFileEntryBasic(
 			_STRIPPED_FILE_NAME, _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
-		testAddFileEntryBasic(_STRIPPED_FILE_NAME, "", "", _STRIPPED_FILE_NAME);
-		testAddFileEntryBasic("", _FILE_NAME, "txt", _FILE_NAME);
-		testAddFileEntryBasic("", _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
+	}
 
+	@Test
+	public void testAddFileEntryBasic07() throws Exception {
+		testAddFileEntryBasic(_STRIPPED_FILE_NAME, "", "", _STRIPPED_FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic08() throws Exception {
+		testAddFileEntryBasic("", _FILE_NAME, "txt", _FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic09() throws Exception {
+		testAddFileEntryBasic("", _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
+	}
+
+	@Test
+	public void testAddFileEntryBasic10() throws Exception {
 		try {
 			addFileEntry(false, "", "");
 

--- a/portal-service/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
@@ -15,8 +15,6 @@
 package com.liferay.portal.kernel.search;
 
 import com.liferay.portal.kernel.cluster.messaging.ClusterBridgeMessageListener;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.InvokerMessageListener;
 import com.liferay.portal.kernel.messaging.MessageBus;
@@ -29,7 +27,6 @@ import com.liferay.portal.kernel.search.messaging.SearchWriterMessageListener;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Map;
@@ -72,22 +69,6 @@ public abstract class AbstractSearchEngineConfigurator {
 			SearchEngineUtil.setDefaultSearchEngineId(_originalSearchEngineId);
 
 			_originalSearchEngineId = null;
-		}
-	}
-
-	/**
-	 * @deprecated {@link #setSearchEngines(Map)}
-	 */
-	public void setSearchEngines(List<SearchEngine> searchEngines) {
-		_searchEngines = new HashMap<String, SearchEngine>();
-
-		if (searchEngines.size() == 1) {
-			SearchEngine searchEngine = searchEngines.get(0);
-
-			_searchEngines.put(SearchEngineUtil.SYSTEM_ENGINE_ID, searchEngine);
-		}
-		else {
-			_log.error("Unable to determine search engine IDs");
 		}
 	}
 
@@ -347,9 +328,6 @@ public abstract class AbstractSearchEngineConfigurator {
 				invokerMessageListener);
 		}
 	}
-
-	private static Log _log = LogFactoryUtil.getLog(
-		AbstractSearchEngineConfigurator.class);
 
 	private String _originalSearchEngineId;
 	private List<SearchEngineRegistration> _searchEngineRegistrations =

--- a/portal-web/docroot/html/portlet/announcements/tabs1.jsp
+++ b/portal-web/docroot/html/portlet/announcements/tabs1.jsp
@@ -26,7 +26,7 @@ tabs1URL.setParameter("tabs1", tabs1);
 
 String tabs1Names = "entries";
 
-if (PortletPermissionUtil.contains(permissionChecker, layout, PortletKeys.ANNOUNCEMENTS, ActionKeys.ADD_ENTRY)) {
+if (PortletPermissionUtil.contains(permissionChecker, layout, portletName, ActionKeys.ADD_ENTRY)) {
 	tabs1Names += ",manage-entries";
 }
 %>

--- a/portal-web/docroot/html/portlet/announcements/view.jsp
+++ b/portal-web/docroot/html/portlet/announcements/view.jsp
@@ -27,7 +27,7 @@ portletURL.setParameter("struts_action", "/announcements/view");
 portletURL.setParameter("tabs1", tabs1);
 %>
 
-<c:if test="<%= !portletName.equals(PortletKeys.ALERTS) || (portletName.equals(PortletKeys.ALERTS) && PortletPermissionUtil.contains(permissionChecker, layout, PortletKeys.ANNOUNCEMENTS, ActionKeys.ADD_ENTRY)) %>">
+<c:if test="<%= !portletName.equals(PortletKeys.ALERTS) || (portletName.equals(PortletKeys.ALERTS) && PortletPermissionUtil.contains(permissionChecker, layout, PortletKeys.ALERTS, ActionKeys.ADD_ENTRY)) %>">
 	<liferay-util:include page="/html/portlet/announcements/tabs1.jsp" />
 </c:if>
 


### PR DESCRIPTION
Issue: on the Alerts portlet the user can not create new entry despite the fact that you have permission.

This PR has been send twice, first Sergio said to Zsolt to use model level permission checking but in this case since both announcements and alerts portlet use the same codebase we wouldn't be able to separate the permissions except we separate-recreate the whole code. So for that solution Brian said: 

"ADD_ENTRY is something that should be checked on the portlet, and not on the announcements entry itself."

So he followed that way, and make the permission checking to use the portlet level.

Thanks,
Daniel
