### PR TITLE
[TECHNICAL-SUPPOR] LPS-26805 Nested-portlets missing from merge

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -1394,6 +1394,23 @@ public class LayoutImporter {
 				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID,
 				layoutTemplateId);
 
+			String nestedColumnIds = newTypeSettingsProperties.getProperty(
+				LayoutTypePortletConstants.NESTED_COLUMN_IDS, StringPool.BLANK);
+
+			if (!nestedColumnIds.equals(StringPool.BLANK)) {
+				previousTypeSettingsProperties.setProperty(
+					LayoutTypePortletConstants.NESTED_COLUMN_IDS,
+					nestedColumnIds);
+
+				for (String nestedColumnId :
+					StringUtil.split(nestedColumnIds)) {
+
+					previousTypeSettingsProperties.setProperty(
+						nestedColumnId,
+						newTypeSettingsProperties.getProperty(nestedColumnId));
+				}
+			}
+
 			LayoutTemplate newLayoutTemplate =
 				LayoutTemplateLocalServiceUtil.getLayoutTemplate(
 					layoutTemplateId, false, null);


### PR DESCRIPTION
Hi Juan,

This PR is about to fix the issue when you add new member to a group and during merge layouts the portlets inside on a nested-portlet will be missing from the result page. The original issue occurs on 6.0.x only but the code exists on trunk as-is, the only difference is now we handle merging sites differently. With using parameter: 

user.groups.copy.layouts.to.user.personal.site=true

you can force the portal to use the old way, so you can reproduce the problem on trunk as well. As the comment above this param says it is a deprecated behavior now, but as we discussed the method we need to fix here is really not deprecated, so it is possible to reproduce the problem any time if somebody just calls this method from his code.

Thanks,
Daniel
