### PR TITLE
LPS-27064 OpenAM authentication lost

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/sso/opensso/OpenSSOFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/sso/opensso/OpenSSOFilter.java
@@ -25,6 +25,7 @@ import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.WebKeys;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -119,13 +120,13 @@ public class OpenSSOFilter extends BasePortalFilter {
 			return;
 		}
 
+		HttpSession session = request.getSession();
+
 		if (authenticated) {
 
 			// LEP-5943
 
 			String newSubjectId = OpenSSOUtil.getSubjectId(request, serviceUrl);
-
-			HttpSession session = request.getSession();
 
 			String oldSubjectId = (String)session.getAttribute(_SUBJECT_ID_KEY);
 
@@ -143,6 +144,9 @@ public class OpenSSOFilter extends BasePortalFilter {
 			processFilter(OpenSSOFilter.class, request, response, filterChain);
 
 			return;
+		}
+		else if (session.getAttribute(WebKeys.USER) != null) {
+			session.invalidate();
 		}
 
 		if (!PropsValues.AUTH_FORWARD_BY_LAST_PATH ||


### PR DESCRIPTION
Hi Juan,

this PR is to fix the problem when you use OpenSSO auth and the SSO provider kill/expire your session in the background and when you next time refresh your portal page it requires a new login, then after you logged back successfully and refresh your page or send a new request to the server you will lost your session again and you need to auth again. This happens because not the portal logs you out and your session is not invalidated on the Liferay site, so next time the request can get some object from this invalid session like userId and it cause an invalid state in the request as well. 

To fix the problem we had to invalidate the user session on the first point where we can realize the SSO stopped the session on the background. This point is in the OpenSSO filter, and I suggested this solution to Tamas because I think it has the least effect on the portal as well. To prevent to expire the session always (every time when some use hit the page first time without any previous expired session) we put an extra check for the User object on the session.

To reproduce the problem please follow the steps described in: LPP-2929

Thanks,
Daniel
