### PR TITLE
LPS 27290.display.style.portlet

### DIFF
--- a/portal-impl/src/com/liferay/portlet/display_styles/action/ViewAction.java
+++ b/portal-impl/src/com/liferay/portlet/display_styles/action/ViewAction.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.display_styles.action;
+
+import com.liferay.portal.kernel.servlet.DynamicServletRequest;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.struts.PortletAction;
+import com.liferay.portlet.RenderRequestImpl;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+
+import javax.portlet.PortletConfig;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+public class ViewAction extends PortletAction {
+
+	@Override
+	public ActionForward render(
+			ActionMapping mapping, ActionForm form, PortletConfig portletConfig,
+			RenderRequest renderRequest, RenderResponse renderResponse)
+			throws Exception {
+
+		RenderRequestImpl renderRequestImpl = (RenderRequestImpl)renderRequest;
+
+		DynamicServletRequest dynamicRequest =
+				(DynamicServletRequest)renderRequestImpl.getHttpServletRequest();
+
+		if (Validator.isNull(
+			ParamUtil.getString(renderRequest, "ddmResource"))) {
+				dynamicRequest.setParameter(
+					"ddmResource",
+					portletConfig.getInitParameter("ddm-resource"));
+		}
+
+		if (Validator.isNull(
+			ParamUtil.getString(renderRequest, "ddmResourceActionId"))) {
+				dynamicRequest.setParameter(
+					"ddmResourceActionId",
+					portletConfig.getInitParameter("ddm-resource-action-id"));
+		}
+
+		return mapping.findForward("portlet.display_styles.view");
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/display_styles/action/ViewAction.java
+++ b/portal-impl/src/com/liferay/portlet/display_styles/action/ViewAction.java
@@ -20,14 +20,17 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.struts.PortletAction;
 import com.liferay.portlet.RenderRequestImpl;
 
-import org.apache.struts.action.ActionForm;
-import org.apache.struts.action.ActionForward;
-import org.apache.struts.action.ActionMapping;
-
 import javax.portlet.PortletConfig;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+
+/**
+ * @author Eduardo Garcia
+ */
 public class ViewAction extends PortletAction {
 
 	@Override
@@ -39,7 +42,7 @@ public class ViewAction extends PortletAction {
 		RenderRequestImpl renderRequestImpl = (RenderRequestImpl)renderRequest;
 
 		DynamicServletRequest dynamicRequest =
-				(DynamicServletRequest)renderRequestImpl.getHttpServletRequest();
+			(DynamicServletRequest)renderRequestImpl.getHttpServletRequest();
 
 		if (Validator.isNull(
 			ParamUtil.getString(renderRequest, "ddmResource"))) {

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/action/EditTemplateAction.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/action/EditTemplateAction.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.service.ServiceContext;
@@ -72,7 +73,7 @@ public class EditTemplateAction extends PortletAction {
 				template = updateTemplate(actionRequest);
 			}
 			else if (cmd.equals(Constants.DELETE)) {
-				deleteTemplate(actionRequest);
+				deleteTemplates(actionRequest);
 			}
 
 			if (Validator.isNotNull(cmd)) {
@@ -140,13 +141,23 @@ public class EditTemplateAction extends PortletAction {
 				renderRequest, "portlet.dynamic_data_mapping.edit_template"));
 	}
 
-	protected void deleteTemplate(ActionRequest actionRequest)
+	protected void deleteTemplates(ActionRequest actionRequest)
 		throws Exception {
+
+		long[] deleteTemplateIds = null;
 
 		long templateId = ParamUtil.getLong(actionRequest, "templateId");
 
 		if (templateId > 0) {
-			DDMTemplateServiceUtil.deleteTemplate(templateId);
+			deleteTemplateIds = new long[] {templateId};
+		}
+		else {
+			deleteTemplateIds = StringUtil.split(
+				ParamUtil.getString(actionRequest, "deleteTemplateIds"), 0L);
+		}
+
+		for (long deleteTemplateId : deleteTemplateIds) {
+			DDMTemplateServiceUtil.deleteTemplate(deleteTemplateId);
 		}
 	}
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -120,6 +120,7 @@ javax.portlet.title.17=CSZ Search
 javax.portlet.title.180=User Statistics
 javax.portlet.title.181=Group Statistics
 javax.portlet.title.182=Recycle Bin
+javax.portlet.title.183=Display Styles
 javax.portlet.title.18=Maps
 javax.portlet.title.19=Message Boards
 javax.portlet.title.20=Documents and Media

--- a/portal-web/docroot/WEB-INF/liferay-display.xml
+++ b/portal-web/docroot/WEB-INF/liferay-display.xml
@@ -86,6 +86,7 @@
 		<portlet id="178" />
 		<portlet id="179" />
 		<portlet id="182" />
+		<portlet id="183" />
 	</category>
 	<category name="category.news">
 		<portlet id="39" />

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1916,6 +1916,26 @@
 		<header-portlet-css>/html/portlet/document_library/css/main.css</header-portlet-css>
 		<css-class-wrapper>portlet-trash</css-class-wrapper>
 	</portlet>
+	<portlet>
+		<portlet-name>183</portlet-name>
+		<icon>/html/icons/dynamic_data_lists.png</icon>
+		<struts-path>display_styles</struts-path>
+		<parent-struts-path>dynamic_data_mapping</parent-struts-path>
+		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
+		<portlet-data-handler-class>com.liferay.portlet.blogs.lar.BlogsPortletDataHandlerImpl</portlet-data-handler-class>
+		<control-panel-entry-category>content</control-panel-entry-category>
+		<control-panel-entry-weight>25.0</control-panel-entry-weight>
+		<preferences-owned-by-group>true</preferences-owned-by-group>
+		<use-default-template>false</use-default-template>
+		<scopeable>true</scopeable>
+		<private-request-attributes>false</private-request-attributes>
+		<private-session-attributes>false</private-session-attributes>
+		<autopropagated-parameters>chooseCallback,ddmResource,ddmResourceActionId,saveCallback,scopeAvailableFields,scopeStorageType,scopeStructureName,scopeStructureType,scopeTemplateMode,scopeTemplateType,showGlobalScope,showManageTemplates,showToolbar,templateHeaderTitle</autopropagated-parameters>
+		<render-weight>50</render-weight>
+		<header-portlet-css>/html/portlet/dynamic_data_mapping/css/main.css</header-portlet-css>
+		<css-class-wrapper>portlet-dynamic-data-mapping</css-class-wrapper>
+		<add-default-resource>true</add-default-resource>
+	</portlet>
 	<role-mapper>
 		<role-name>administrator</role-name>
 		<role-link>Administrator</role-link>

--- a/portal-web/docroot/WEB-INF/portlet-custom.xml
+++ b/portal-web/docroot/WEB-INF/portlet-custom.xml
@@ -3250,7 +3250,7 @@
 	<portlet>
 		<portlet-name>182</portlet-name>
 		<display-name>Trash</display-name>
-		<portlet-class>com.liferay.util.bridges.mvc.MVCPortlet</portlet-class>
+		<portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
 		<init-param>
 			<name>template-path</name>
 			<value>/html/portlet/trash/</value>

--- a/portal-web/docroot/WEB-INF/portlet-custom.xml
+++ b/portal-web/docroot/WEB-INF/portlet-custom.xml
@@ -3250,7 +3250,7 @@
 	<portlet>
 		<portlet-name>182</portlet-name>
 		<display-name>Trash</display-name>
-		<portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
+		<portlet-class>com.liferay.util.bridges.mvc.MVCPortlet</portlet-class>
 		<init-param>
 			<name>template-path</name>
 			<value>/html/portlet/trash/</value>
@@ -3269,6 +3269,31 @@
 		</security-role-ref>
 		<security-role-ref>
 			<role-name>user</role-name>
+		</security-role-ref>
+	</portlet>
+	<portlet>
+		<portlet-name>183</portlet-name>
+		<display-name>Display Styles</display-name>
+		<portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
+		<init-param>
+			<name>ddm-resource</name>
+			<value>com.liferay.portlet.assetpublisher</value>
+		</init-param>
+		<init-param>
+			<name>ddm-resource-action-id</name>
+			<value>ADD_DISPLAY_STYLE</value>
+		</init-param>
+		<init-param>
+			<name>view-action</name>
+			<value>/display_styles/view</value>
+		</init-param>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
+		<security-role-ref>
+			<role-name>administrator</role-name>
 		</security-role-ref>
 	</portlet>
 	<custom-portlet-mode>

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -458,6 +458,13 @@
 			<forward name="portlet.users_admin.error" path="portlet.directory.error" />
 		</action>
 
+		<!-- Display Styles -->
+
+		<action path="/display_styles/view" type="com.liferay.portlet.display_styles.action.ViewAction" >
+			<forward name="portlet.display_styles.view" path="portlet.dynamic_data_mapping.view_template" />
+			<forward name="portlet.dynamic_data_mapping.error" path="portlet.dynamic_data_mapping.error" />
+		</action>
+
 		<!-- Dockbar -->
 
 		<action path="/dockbar/view" forward="portlet.dockbar.view" />

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
@@ -39,6 +39,8 @@ portletURL.setParameter("tabs1", tabs1);
 portletURL.setParameter("backURL", backURL);
 portletURL.setParameter("classNameId", String.valueOf(classNameId));
 portletURL.setParameter("classPK", String.valueOf(classPK));
+
+boolean showDeleteTemplatesButton = DDMPermission.contains(permissionChecker, scopeGroupId, ddmResource, ActionKeys.DELETE) ;
 %>
 
 <c:choose>
@@ -47,6 +49,8 @@ portletURL.setParameter("classPK", String.valueOf(classPK));
 			backURL="<%= backURL %>"
 			title='<%= LanguageUtil.format(pageContext, (Validator.isNull(templateHeaderTitle) ? "templates-for-structure-x" : templateHeaderTitle), structure.getName(locale), false) %>'
 		/>
+	</c:when>
+	<c:when test='<%= portletDisplay.getId().equals("183") %>'>
 	</c:when>
 	<c:otherwise>
 		<liferay-ui:header
@@ -70,100 +74,129 @@ portletURL.setParameter("classPK", String.valueOf(classPK));
 
 <div class="separator"></div>
 
-<liferay-ui:search-container
-	searchContainer="<%= new TemplateSearch(renderRequest, portletURL) %>"
->
-	<liferay-ui:search-container-results>
-		<%@ include file="/html/portlet/dynamic_data_mapping/template_search_results.jspf" %>
-	</liferay-ui:search-container-results>
+<c:if test="<%= showDeleteTemplatesButton %>">
+	<aui:button onClick='<%= renderResponse.getNamespace() + "deleteTemplates();" %>' value="delete" />
+</c:if>
 
-	<liferay-ui:search-container-row
-		className="com.liferay.portlet.dynamicdatamapping.model.DDMTemplate"
-		keyProperty="templateId"
-		modelVar="template"
+<aui:form action="<%= portletURL.toString() %>" method="get" name="fm1">
+	<aui:input name="<%= Constants.CMD %>" type="hidden" />
+	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+	<aui:input name="templateIds" type="hidden" />
+
+	<liferay-ui:search-container
+		searchContainer="<%= new TemplateSearch(renderRequest, portletURL) %>"
+		rowChecker="<%= new RowChecker(renderResponse) %>"
 	>
+		<liferay-ui:search-container-results>
+			<%@ include file="/html/portlet/dynamic_data_mapping/template_search_results.jspf" %>
+		</liferay-ui:search-container-results>
 
-		<%
-		String rowHREF = null;
-
-		if (Validator.isNotNull(chooseCallback)) {
-			StringBundler sb = new StringBundler(7);
-
-			sb.append("javascript:Liferay.Util.getOpener()['");
-			sb.append(HtmlUtil.escapeJS(chooseCallback));
-			sb.append("']('");
-			sb.append(template.getTemplateId());
-			sb.append("', '");
-			sb.append(HtmlUtil.escapeJS(template.getName(locale)));
-			sb.append("', Liferay.Util.getWindow());");
-
-			rowHREF = sb.toString();
-		}
-		else {
-			PortletURL rowURL = renderResponse.createRenderURL();
-
-			rowURL.setParameter("struts_action", "/dynamic_data_mapping/edit_template");
-			rowURL.setParameter("redirect", currentURL);
-			rowURL.setParameter("backURL", currentURL);
-			rowURL.setParameter("groupId", String.valueOf(template.getGroupId()));
-			rowURL.setParameter("templateId", String.valueOf(template.getTemplateId()));
-			rowURL.setParameter("classNameId", String.valueOf(classNameId));
-			rowURL.setParameter("classPK", String.valueOf(classPK));
-			rowURL.setParameter("type", template.getType());
-
-			rowHREF = rowURL.toString();
-		}
-		%>
-
-		<liferay-ui:search-container-column-text
-			href="<%= rowHREF %>"
-			name="id"
-			property="templateId"
-		/>
-
-		<liferay-ui:search-container-column-text
-			href="<%= rowHREF %>"
-			name="name"
-			value="<%= LanguageUtil.get(pageContext, template.getName(locale)) %>"
-		/>
-
-		<c:if test="<%= Validator.isNull(templateTypeValue) %>">
-			<liferay-ui:search-container-column-text
-				href="<%= rowHREF %>"
-				name="type"
-				value="<%= LanguageUtil.get(pageContext, template.getType()) %>"
-			/>
-		</c:if>
-
-		<liferay-ui:search-container-column-text
-			href="<%= rowHREF %>"
-			name="mode"
-			value="<%= LanguageUtil.get(pageContext, template.getMode()) %>"
-		/>
-
-		<liferay-ui:search-container-column-text
-			href="<%= rowHREF %>"
-			name="language"
-			value="<%= LanguageUtil.get(pageContext, template.getLanguage()) %>"
-		/>
-
-		<liferay-ui:search-container-column-text
-			buffer="buffer"
-			href="<%= rowHREF %>"
-			name="modified-date"
+		<liferay-ui:search-container-row
+			className="com.liferay.portlet.dynamicdatamapping.model.DDMTemplate"
+			keyProperty="templateId"
+			modelVar="template"
 		>
 
 			<%
-			buffer.append(dateFormatDateTime.format(template.getModifiedDate()));
+			String rowHREF = null;
+
+			if (Validator.isNotNull(chooseCallback)) {
+				StringBundler sb = new StringBundler(7);
+
+				sb.append("javascript:Liferay.Util.getOpener()['");
+				sb.append(HtmlUtil.escapeJS(chooseCallback));
+				sb.append("']('");
+				sb.append(template.getTemplateId());
+				sb.append("', '");
+				sb.append(HtmlUtil.escapeJS(template.getName(locale)));
+				sb.append("', Liferay.Util.getWindow());");
+
+				rowHREF = sb.toString();
+			}
+			else {
+				PortletURL rowURL = renderResponse.createRenderURL();
+
+				rowURL.setParameter("struts_action", "/dynamic_data_mapping/edit_template");
+				rowURL.setParameter("redirect", currentURL);
+				rowURL.setParameter("backURL", currentURL);
+				rowURL.setParameter("groupId", String.valueOf(template.getGroupId()));
+				rowURL.setParameter("templateId", String.valueOf(template.getTemplateId()));
+				rowURL.setParameter("classNameId", String.valueOf(classNameId));
+				rowURL.setParameter("classPK", String.valueOf(classPK));
+				rowURL.setParameter("type", template.getType());
+
+				rowHREF = rowURL.toString();
+			}
 			%>
 
-		</liferay-ui:search-container-column-text>
+			<liferay-ui:search-container-column-text
+				href="<%= rowHREF %>"
+				name="id"
+				property="templateId"
+			/>
 
-		<liferay-ui:search-container-column-jsp
-			align="right"
-			path="/html/portlet/dynamic_data_mapping/template_action.jsp"
-		/>
-	</liferay-ui:search-container-row>
+			<liferay-ui:search-container-column-text
+				href="<%= rowHREF %>"
+				name="name"
+				value="<%= LanguageUtil.get(pageContext, template.getName(locale)) %>"
+			/>
 
-	<liferay-ui:search-iterator />
-</liferay-ui:search-container>
+			<c:if test="<%= Validator.isNull(templateTypeValue) %>">
+				<liferay-ui:search-container-column-text
+					href="<%= rowHREF %>"
+					name="type"
+					value="<%= LanguageUtil.get(pageContext, template.getType()) %>"
+				/>
+			</c:if>
+
+			<liferay-ui:search-container-column-text
+				href="<%= rowHREF %>"
+				name="mode"
+				value="<%= LanguageUtil.get(pageContext, template.getMode()) %>"
+			/>
+
+			<liferay-ui:search-container-column-text
+				href="<%= rowHREF %>"
+				name="language"
+				value="<%= LanguageUtil.get(pageContext, template.getLanguage()) %>"
+			/>
+
+			<liferay-ui:search-container-column-text
+				buffer="buffer"
+				href="<%= rowHREF %>"
+				name="modified-date"
+			>
+
+				<%
+				buffer.append(dateFormatDateTime.format(template.getModifiedDate()));
+				%>
+
+			</liferay-ui:search-container-column-text>
+
+			<liferay-ui:search-container-column-jsp
+				align="right"
+				path="/html/portlet/dynamic_data_mapping/template_action.jsp"
+			/>
+		</liferay-ui:search-container-row>
+
+		<liferay-ui:search-iterator />
+	</liferay-ui:search-container>
+</aui:form>
+
+<c:if test="<%= showDeleteTemplatesButton %>">
+	<aui:script>
+		Liferay.provide(
+			window,
+			'<portlet:namespace />deleteTemplates',
+			function() {
+				if (confirm('<%= UnicodeLanguageUtil.get(pageContext, "are-you-sure-you-want-to-delete-this") %>')) {
+					document.<portlet:namespace />fm1.method = "post";
+					document.<portlet:namespace />fm1.<portlet:namespace /><%= Constants.CMD %>.value = "<%= Constants.DELETE %>";
+					document.<portlet:namespace />fm1.<portlet:namespace />templateIds.value = Liferay.Util.listCheckedExcept(document.<portlet:namespace />fm1, "<portlet:namespace />allRowIds");
+					submitForm(document.<portlet:namespace />fm1, "<portlet:actionURL><portlet:param name="struts_action" value="/dynamic_data_mapping/edit_template" /></portlet:actionURL>");
+				}
+			},
+			['liferay-util-list-fields']
+		);
+	</aui:script>
+</c:if>

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
@@ -39,8 +39,6 @@ portletURL.setParameter("tabs1", tabs1);
 portletURL.setParameter("backURL", backURL);
 portletURL.setParameter("classNameId", String.valueOf(classNameId));
 portletURL.setParameter("classPK", String.valueOf(classPK));
-
-boolean showDeleteTemplatesButton = DDMPermission.contains(permissionChecker, scopeGroupId, ddmResource, ActionKeys.DELETE) ;
 %>
 
 <c:choose>
@@ -72,20 +70,14 @@ boolean showDeleteTemplatesButton = DDMPermission.contains(permissionChecker, sc
 	/>
 </aui:form>
 
-<div class="separator"></div>
-
-<c:if test="<%= showDeleteTemplatesButton %>">
-	<aui:button onClick='<%= renderResponse.getNamespace() + "deleteTemplates();" %>' value="delete" />
-</c:if>
-
 <aui:form action="<%= portletURL.toString() %>" method="get" name="fm1">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" />
 	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-	<aui:input name="templateIds" type="hidden" />
+	<aui:input name="deleteTemplateIds" type="hidden" />
 
 	<liferay-ui:search-container
-		searchContainer="<%= new TemplateSearch(renderRequest, portletURL) %>"
 		rowChecker="<%= new RowChecker(renderResponse) %>"
+		searchContainer="<%= new TemplateSearch(renderRequest, portletURL) %>"
 	>
 		<liferay-ui:search-container-results>
 			<%@ include file="/html/portlet/dynamic_data_mapping/template_search_results.jspf" %>
@@ -179,24 +171,56 @@ boolean showDeleteTemplatesButton = DDMPermission.contains(permissionChecker, sc
 			/>
 		</liferay-ui:search-container-row>
 
+		<div class="separator article-separator"><!-- --></div>
+
+		<c:if test="<%= !results.isEmpty() %>">
+			<aui:button-row>
+				<aui:button cssClass="delete-templates-button" onClick='<%= renderResponse.getNamespace() + "deleteTemplates();" %>' value="delete" />
+			</aui:button-row>
+
+			<br /><br />
+		</c:if>
+
 		<liferay-ui:search-iterator />
 	</liferay-ui:search-container>
 </aui:form>
 
-<c:if test="<%= showDeleteTemplatesButton %>">
-	<aui:script>
-		Liferay.provide(
-			window,
-			'<portlet:namespace />deleteTemplates',
-			function() {
-				if (confirm('<%= UnicodeLanguageUtil.get(pageContext, "are-you-sure-you-want-to-delete-this") %>')) {
-					document.<portlet:namespace />fm1.method = "post";
-					document.<portlet:namespace />fm1.<portlet:namespace /><%= Constants.CMD %>.value = "<%= Constants.DELETE %>";
-					document.<portlet:namespace />fm1.<portlet:namespace />templateIds.value = Liferay.Util.listCheckedExcept(document.<portlet:namespace />fm1, "<portlet:namespace />allRowIds");
-					submitForm(document.<portlet:namespace />fm1, "<portlet:actionURL><portlet:param name="struts_action" value="/dynamic_data_mapping/edit_template" /></portlet:actionURL>");
-				}
-			},
-			['liferay-util-list-fields']
-		);
-	</aui:script>
-</c:if>
+<aui:script>
+	Liferay.provide(
+		window,
+		'<portlet:namespace />deleteTemplates',
+		function() {
+			if (confirm('<%= UnicodeLanguageUtil.get(pageContext, "are-you-sure-you-want-to-delete-this") %>')) {
+				document.<portlet:namespace />fm1.method = "post";
+				document.<portlet:namespace />fm1.<portlet:namespace /><%= Constants.CMD %>.value = "<%= Constants.DELETE %>";
+				document.<portlet:namespace />fm1.<portlet:namespace />deleteTemplateIds.value = Liferay.Util.listCheckedExcept(document.<portlet:namespace />fm1, "<portlet:namespace />allRowIds");
+				submitForm(document.<portlet:namespace />fm1, "<portlet:actionURL><portlet:param name="struts_action" value="/dynamic_data_mapping/edit_template" /></portlet:actionURL>");
+			}
+		},
+		['liferay-util-list-fields']
+	);
+</aui:script>
+
+<aui:script use="aui-base">
+	var buttons = A.all('.delete-templates-button');
+
+	if (buttons.size()) {
+		var toggleDisabled = A.bind(Liferay.Util.toggleDisabled, Liferay.Util, ':button');
+
+		var resultsGrid = A.one('.results-grid');
+
+		if (resultsGrid) {
+			resultsGrid.delegate(
+					'click',
+					function(event) {
+						var disabled = (resultsGrid.one(':checked') == null);
+
+						toggleDisabled(disabled);
+					},
+					':checkbox'
+			);
+		}
+
+		toggleDisabled(true);
+	}
+</aui:script>


### PR DESCRIPTION
ASPECTOS DESTACABLES:
- Se ha creado el portlet display-styles de tipo panel de control. Este portlet utiliza Struts para aprovechar las vistas y acciones del portlet dynamic-data-mapping para templates. Sólo para la vista ha sido necesario añadir una clase ViewAction que rellena los parámetros necesarios en el request (autopropagados al resto de vistas) y redirige a la vista de templates de DDM-portlet.
- Ha sido necesario modificar el view_template.jsp de DDM-portlet para que no se muestre el título "Display Styles" si el portletId es 183 (Display Styles). No es una solución muy elegante pero de algún  modo hay que evitar que aparezca ya que duplica al nombre del portlet en el panel de control. Podemos discutir otras opciones.
- Se han extendido las vistas y acciones de DDM-portlet para permitir el borrado masivo de templates. Para ello se han seguido los mismos criterios que en el portlet de JournalArticle, habilitando por JS el botón de Delete cuando se ha seleccionado al menos una fila.

VALIDACIÓN:
- Pruebas realizadas tras los cambios: Ver, Añadir, Actualizar, Eliminar templates mediante las acciones existentes previamente. Borrado de templates mediante selección múltiple. Se repiten las mismas pruebas desde AssetPublisher ->Config -> Manage Display Styles. 
- Format source sin errores

PENDIENTE

Modificar el icono del portlet cuando nos lo proporcionen (actualmente utiliza el mismo que Dynamic Data List).
