### PR TITLE
LPS-27081 Web Content Templates do not translate HTML tags in Text Area fields

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/util/ContentTransformerListener.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/ContentTransformerListener.java
@@ -137,7 +137,12 @@ public class ContentTransformerListener extends BaseTransformerListener {
 			if (dynamicContent != null) {
 				String text = dynamicContent.getText();
 
-				text = HtmlUtil.escape(text);
+				String type = el.attributeValue("type", StringPool.BLANK);
+
+				if (!type.equals("text_area")) {
+					text = HtmlUtil.escape(text);
+				}
+
 				text = HtmlUtil.stripComments(text);
 				text = HtmlUtil.stripHtml(text);
 				text = text.trim();


### PR DESCRIPTION
Please check my changes.

It has been tested for Web Content with and without structures:
- For those without structure, they have always a text_area filed, so text_area's text won't be escaped.
- For those with structure, there are two cases:
  - with text_area: the text_area's text won't be escaped
  - without text_area but other text inputs (text_box, text): only text_area's text won't be escaped.

Thanks!
