### PR TITLE
LPS-27731 DDM Search Fails

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/persistence/DDMTemplateFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/persistence/DDMTemplateFinderImpl.java
@@ -62,7 +62,7 @@ public class DDMTemplateFinderImpl
 		if (Validator.isNotNull(keywords)) {
 			names = CustomSQLUtil.keywords(keywords);
 			descriptions = CustomSQLUtil.keywords(keywords, false);
-			languages = CustomSQLUtil.keywords(keywords, false);
+			languages = CustomSQLUtil.keywords(languages, false);
 		}
 		else {
 			andOperator = true;
@@ -116,7 +116,7 @@ public class DDMTemplateFinderImpl
 		if (Validator.isNotNull(keywords)) {
 			names = CustomSQLUtil.keywords(keywords);
 			descriptions = CustomSQLUtil.keywords(keywords, false);
-			languages = CustomSQLUtil.keywords(keywords, false);
+			languages = CustomSQLUtil.keywords(languages, false);
 		}
 		else {
 			andOperator = true;


### PR DESCRIPTION
En los métodos count en los que no se pasa explícitamente el parámetro "languages", éste se estaba obteniendo a partir de los keywords (lo cual es incorrecto). Si no se pasa el parámetro explicitamente, se debe establecer a null, como ocurre en los métodos find.
