### PR TITLE
LPS-27774 Delete DDM Structures which have DDM Templates

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -170,7 +170,18 @@ public class DDMStructureLocalServiceImpl
 		if (ddmStructureLinkPersistence.countByStructureId(
 				structure.getStructureId()) > 0) {
 
-			throw new RequiredStructureException();
+			throw new RequiredStructureException(
+				RequiredStructureException.REFERENCED_OBJECT);
+		}
+
+		long classNameId = PortalUtil.getClassNameId(DDMStructure.class);
+
+		if (ddmTemplatePersistence.countByG_C_C(
+				structure.getGroupId(), classNameId,
+				structure.getPrimaryKey()) > 0) {
+
+			throw new RequiredStructureException(
+				RequiredStructureException.REFERENCED_TEMPLATE);
 		}
 
 		// Structure

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -420,6 +420,7 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+they-are-referenced-by-other-objects=They are referenced by other objects.
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/RequiredStructureException.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/RequiredStructureException.java
@@ -21,8 +21,16 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class RequiredStructureException extends PortalException {
 
+	public static final int REFERENCED_OBJECT = 1;
+
+	public static final int REFERENCED_TEMPLATE = 2;
+
 	public RequiredStructureException() {
 		super();
+	}
+
+	public RequiredStructureException(int type) {
+		_type = type;
 	}
 
 	public RequiredStructureException(String msg) {
@@ -36,5 +44,11 @@ public class RequiredStructureException extends PortalException {
 	public RequiredStructureException(Throwable cause) {
 		super(cause);
 	}
+
+	public int getType() {
+		return _type;
+	}
+
+	private int _type;
 
 }

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
@@ -25,7 +25,22 @@ portletURL.setParameter("struts_action", "/dynamic_data_mapping/view");
 portletURL.setParameter("tabs1", tabs1);
 %>
 
-<liferay-ui:error exception="<%= RequiredStructureException.class %>" message="required-structures-could-not-be-deleted" />
+<liferay-ui:error exception="<%= RequiredStructureException.class %>">
+	<liferay-ui:message key="required-structures-could-not-be-deleted" />
+
+	<%
+		RequiredStructureException rse = (RequiredStructureException)errorException;
+	%>
+
+	<c:if test="<%= rse.getType() == RequiredStructureException.REFERENCED_OBJECT %>">
+		<liferay-ui:message key="they-are-referenced-by-other-objects" />
+	</c:if>
+
+	<c:if test="<%= rse.getType() == RequiredStructureException.REFERENCED_TEMPLATE %>">
+		<liferay-ui:message key="they-are-referenced-by-templates" />
+	</c:if>
+
+</liferay-ui:error>
 
 <c:if test="<%= showToolbar %>">
 	<liferay-util:include page="/html/portlet/dynamic_data_mapping/toolbar.jsp">


### PR DESCRIPTION
No se permite borrar DDMStructures que tienen DDMTemplates asociados. Además, se añade más información a los mensajes de error cuando falla el borrado.
