### PR TITLE
LPS-277789 Redirect after creating DDMStructure

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/template_toolbar.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/template_toolbar.jsp
@@ -92,7 +92,6 @@ long classPK = ParamUtil.getLong(request, "classPK");
 				<portlet:renderURL var="addTemplateURL">
 					<portlet:param name="struts_action" value="/dynamic_data_mapping/edit_template" />
 					<portlet:param name="redirect" value="<%= viewTemplatesURL %>" />
-					<portlet:param name="backURL" value="<%= viewTemplatesURL %>" />
 					<portlet:param name="groupId" value="<%= String.valueOf(scopeGroupId) %>" />
 					<portlet:param name="classNameId" value="<%= String.valueOf(classNameId) %>" />
 					<portlet:param name="classPK" value="<%= String.valueOf(classPK) %>" />

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/toolbar.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/toolbar.jsp
@@ -33,7 +33,6 @@ String toolbarItem = ParamUtil.getString(request, "toolbarItem", "view-all");
 		<portlet:renderURL var="addStructureURL">
 			<portlet:param name="struts_action" value="/dynamic_data_mapping/edit_structure" />
 			<portlet:param name="redirect" value="<%= viewStructuresURL %>" />
-			<portlet:param name="backURL" value="<%= viewStructuresURL %>" />
 		</portlet:renderURL>
 
 		<span class="lfr-toolbar-button add-button <%= toolbarItem.equals("add") ? "current" : StringPool.BLANK %>">


### PR DESCRIPTION
Eliminado backURL de la renderURL de AddStructure para evitar que se recorte automáticamente el parámetro redirect.
