### PR TITLE
[TECH SUPPORT] LPS-28094

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStore.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStore.java
@@ -184,6 +184,11 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 			repositoryDir + StringPool.SLASH + sb.toString() +
 				StringPool.SLASH + fileNameFragment + ext);
 
+		File parnetFile = new File(
+			repositoryDir + StringPool.SLASH + sb.toString());
+
+		parnetFile.mkdirs();
+
 		return fileNameDir;
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStore.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStore.java
@@ -184,10 +184,11 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 			repositoryDir + StringPool.SLASH + sb.toString() +
 				StringPool.SLASH + fileNameFragment + ext);
 
-		File parnetFile = new File(
-			repositoryDir + StringPool.SLASH + sb.toString());
+		File parentDir = fileNameDir.getParentFile();
 
-		parnetFile.mkdirs();
+		if (!parentDir.exists()) {
+			parentDir.mkdirs();
+		}
 
 		return fileNameDir;
 	}

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStoreTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStoreTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.store;
+
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.ExecutionTestListeners;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vilmos Papp
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class AdvancedFileSystemStoreTest {
+
+	@Test
+	public void testUpdateFileWithMoveFiles() throws Exception {
+		Object[] data = setupStoreFolders();
+		long companyId = (Long)data[0];
+		long repositoryId = (Long)data[1];
+		long newRepositoryId = (Long)data[2];
+		String[] fileNames = new String[] {
+			"1" + _FILE_NAME_EXTENSION, "10" + _FILE_NAME_EXTENSION,
+			"101" + _FILE_NAME_EXTENSION, "110" + _FILE_NAME_EXTENSION,
+			"150" + _FILE_NAME_EXTENSION
+		};
+
+		for (String fileName : fileNames) {
+			_store.updateFile(
+				companyId, repositoryId, newRepositoryId, fileName);
+
+			Assert.assertTrue(
+				_store.hasFile(companyId, newRepositoryId, fileName));
+			Assert.assertFalse(
+				_store.hasFile(companyId, repositoryId, fileName));
+		}
+	}
+
+	protected Object[] setupStoreFolders() throws Exception {
+		long companyId = ServiceTestUtil.nextLong();
+		long repositoryId = ServiceTestUtil.nextLong();
+		long newRepositoryId = ServiceTestUtil.nextLong();
+
+		String fileName;
+		for (int i = 0; i < _FILE_COUNT; i++) {
+			fileName = String.valueOf(i) + _FILE_NAME_EXTENSION;
+
+			_store.addFile(companyId, repositoryId, fileName, _DATA_VERSION_1);
+		}
+
+		return new Object[] {
+			companyId, repositoryId, newRepositoryId};
+	}
+
+	private static final int _DATA_SIZE = 1024 * 65;
+
+	private static final byte[] _DATA_VERSION_1 = new byte[_DATA_SIZE];
+
+	private static final int _FILE_COUNT = 200;
+
+	private static final String _FILE_NAME_EXTENSION = ".txt";
+
+	private static Store _store = new AdvancedFileSystemStore();
+
+	static {
+		for (int i = 0; i < _DATA_SIZE; i++) {
+			_DATA_VERSION_1[i] = (byte)i;
+		}
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStoreTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/store/AdvancedFileSystemStoreTest.java
@@ -14,12 +14,10 @@
 
 package com.liferay.portlet.documentlibrary.store;
 
-import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.ExecutionTestListeners;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
-import com.liferay.portal.test.TransactionalExecutionTestListener;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,26 +26,19 @@ import org.junit.runner.RunWith;
 /**
  * @author Vilmos Papp
  */
-@ExecutionTestListeners(
-	listeners = {
-		EnvironmentExecutionTestListener.class,
-		TransactionalExecutionTestListener.class
-	})
+@ExecutionTestListeners(listeners = {EnvironmentExecutionTestListener.class})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
-@Transactional
 public class AdvancedFileSystemStoreTest {
 
 	@Test
 	public void testUpdateFileWithMoveFiles() throws Exception {
-		Object[] data = setupStoreFolders();
+		Object[] data = initStoreData();
+
 		long companyId = (Long)data[0];
 		long repositoryId = (Long)data[1];
 		long newRepositoryId = (Long)data[2];
-		String[] fileNames = new String[] {
-			"1" + _FILE_NAME_EXTENSION, "10" + _FILE_NAME_EXTENSION,
-			"101" + _FILE_NAME_EXTENSION, "110" + _FILE_NAME_EXTENSION,
-			"150" + _FILE_NAME_EXTENSION
-		};
+
+		String[] fileNames = _store.getFileNames(companyId, repositoryId);
 
 		for (String fileName : fileNames) {
 			_store.updateFile(
@@ -60,27 +51,26 @@ public class AdvancedFileSystemStoreTest {
 		}
 	}
 
-	protected Object[] setupStoreFolders() throws Exception {
+	protected Object[] initStoreData() throws Exception {
 		long companyId = ServiceTestUtil.nextLong();
 		long repositoryId = ServiceTestUtil.nextLong();
 		long newRepositoryId = ServiceTestUtil.nextLong();
 
-		String fileName;
 		for (int i = 0; i < _FILE_COUNT; i++) {
-			fileName = String.valueOf(i) + _FILE_NAME_EXTENSION;
+			String fileName = String.valueOf(i) + _FILE_NAME_EXTENSION;
 
-			_store.addFile(companyId, repositoryId, fileName, _DATA_VERSION_1);
+			_store.addFile(companyId, repositoryId, fileName, _FILE_DATA);
 		}
 
 		return new Object[] {
 			companyId, repositoryId, newRepositoryId};
 	}
 
-	private static final int _DATA_SIZE = 1024 * 65;
-
-	private static final byte[] _DATA_VERSION_1 = new byte[_DATA_SIZE];
+	private static final int _DATA_SIZE = 100;
 
 	private static final int _FILE_COUNT = 200;
+
+	private static final byte[] _FILE_DATA = new byte[_DATA_SIZE];
 
 	private static final String _FILE_NAME_EXTENSION = ".txt";
 
@@ -88,7 +78,7 @@ public class AdvancedFileSystemStoreTest {
 
 	static {
 		for (int i = 0; i < _DATA_SIZE; i++) {
-			_DATA_VERSION_1[i] = (byte)i;
+			_FILE_DATA[i] = (byte)i;
 		}
 	}
 


### PR DESCRIPTION
Hi Juan,

The rootcause of the issue is the renameTo method fails silently except its return value is False that we don't check now, so this is how the file remains on the original folder. In AdvancedFileSystemStore after a given number of documents we introduce a new directory level because of grouping, but the directories in that level doesn't created physically so the renameTo will fail to move something to these folders.

However the fix for the is pretty simple I think we have to make sure this small change works well, so I asked Vilmos to create test for it as well.

Thanks,
Daniel
