### PR TITLE
LPS-30819 Add ADT support for the Media Gallery portlet

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -471,6 +471,8 @@ public class PropsValues {
 
 	public static final String DL_DEFAULT_DISPLAY_VIEW = PropsUtil.get(PropsKeys.DL_DEFAULT_DISPLAY_VIEW);
 
+	public static final String DL_DISPLAY_TEMPLATES_CONFIG = PropsUtil.get(PropsKeys.DL_DISPLAY_TEMPLATES_CONFIG);
+
 	public static final String[] DL_DISPLAY_VIEWS = PropsUtil.getArray(PropsKeys.DL_DISPLAY_VIEWS);
 
 	public static final boolean DL_FILE_ENTRY_COMMENTS_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_COMMENTS_ENABLED));

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet-display-templates.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet-display-templates.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+
+<root/>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.ftl
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.ftl
@@ -1,0 +1,39 @@
+<#--
+
+You can use FreeMarker to define display templates for the Document and Media
+portlet.
+
+A set of variables have been made available for the template developers:
+
+{$ddmTemplateId}: the current template id
+
+{$entries}: the list of file entries that are being shown in this portlet
+
+{$entry}: the file entry when there's only one file entry
+
+{$locale}: the locale of the site
+
+{$requestHash}: a hash that provides access to the attributes of the request
+
+{$renderRequest}: the render request
+
+{$renderResponse}: the render response
+
+{$servletContextHash}: a hash that provides access to the attributes of the
+servlet context
+
+{$taglibLiferayHash}: a hash that provides access to Liferay's taglibs
+
+{$themeDisplay}: the theme display
+
+It is possible to use these variables to create advanced templates to display
+a set of file entries in your document and media portlet. Here's a simple
+template example:
+
+<#list entries as entry>
+	<h1 class="file-title">
+		${entry.getTitle()}
+	</h1>
+</#list>
+
+--#>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.vm
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.vm
@@ -1,0 +1,30 @@
+##
+## You can use Velocity to define display templates for the Document and Media
+## portlet.
+##
+## A set of variables have been made available for the template developers:
+##
+##  $ddmTemplateId: the current template id
+##
+##  $entries: the list of file entries that are being shown in the portlet
+##
+##  $entry: the file entry when there's only one file entry
+##
+##  $locale: the locale of the site
+##
+##  $renderRequest: the render request
+##
+##  $renderResponse: the render response
+##
+##  $themeDisplay: the theme display
+##
+## It is possible to use these variables to create advanced templates to display
+## a set of file entries in your document and media portlet. Here's a simple
+## template example:
+##
+##  #foreach ($entry in $entries)
+##      <h1 class="file-title">
+##          $entry.getTitle()
+##      </h1>
+##  #end
+##

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/template/DocumentLibraryPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/template/DocumentLibraryPortletDisplayTemplateHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.template;
+
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTemplateHandler;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.Locale;
+
+/**
+ * @author Eduardo Garcia
+ */
+public class DocumentLibraryPortletDisplayTemplateHandler
+	extends BasePortletDisplayTemplateHandler {
+
+	public String getClassName() {
+		return FileEntry.class.getName();
+	}
+
+	public String getName(Locale locale) {
+		String portletTitle = PortalUtil.getPortletTitle(
+			PortletKeys.DOCUMENT_LIBRARY, locale);
+
+		return portletTitle.concat(StringPool.SPACE).concat(
+			LanguageUtil.get(locale, "template"));
+	}
+
+	public String getResourceName() {
+		return "com.liferay.portlet.documentlibrary";
+	}
+
+	@Override
+	protected String getTemplatesConfigPath() {
+		return PropsValues.DL_DISPLAY_TEMPLATES_CONFIG;
+	}
+
+	@Override
+	protected String getTemplatesHelpKey() {
+		return PropsKeys.DL_DISPLAY_TEMPLATES_HELP;
+	}
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8509,6 +8509,19 @@
     dl.repository.cmis.delete.depth=1
 
     #
+    # Set the location of the XML file containing the configuration of the
+    # default display templates for the Document Library portlet.
+    #
+    dl.display.templates.config=com/liferay/portlet/documentlibrary/dependencies/portlet-display-templates.xml
+
+    #
+    # Set the location of the help content for the Document Library display
+	# styles templates for each language type.
+    #
+    dl.display.templates.help[ftl]=com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.ftl
+    dl.display.templates.help[vm]=com/liferay/portlet/documentlibrary/dependencies/portlet_display_template_help.vm
+
+    #
     # Set the list of supported display views.
     #
     dl.display.views=icon,descriptive,list

--- a/portal-impl/src/resource-actions/documentlibrary.xml
+++ b/portal-impl/src/resource-actions/documentlibrary.xml
@@ -35,6 +35,7 @@
 				<action-key>ADD_DOCUMENT</action-key>
 				<action-key>ADD_DOCUMENT_TYPE</action-key>
 				<action-key>ADD_FOLDER</action-key>
+				<action-key>ADD_PORTLET_DISPLAY_TEMPLATE</action-key>
 				<action-key>ADD_REPOSITORY</action-key>
 				<action-key>ADD_STRUCTURE</action-key>
 				<action-key>ADD_SHORTCUT</action-key>
@@ -52,6 +53,7 @@
 				<action-key>ADD_DOCUMENT</action-key>
 				<action-key>ADD_DOCUMENT_TYPE</action-key>
 				<action-key>ADD_FOLDER</action-key>
+				<action-key>ADD_PORTLET_DISPLAY_TEMPLATE</action-key>
 				<action-key>ADD_REPOSITORY</action-key>
 				<action-key>ADD_STRUCTURE</action-key>
 				<action-key>ADD_SHORTCUT</action-key>

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -577,6 +577,10 @@ public interface PropsKeys {
 
 	public static final String DL_DEFAULT_DISPLAY_VIEW = "dl.default.display.view";
 
+	public static final String DL_DISPLAY_TEMPLATES_CONFIG = "dl.display.templates.config";
+
+	public static final String DL_DISPLAY_TEMPLATES_HELP = "dl.display.templates.help";
+
 	public static final String DL_DISPLAY_VIEWS = "dl.display.views";
 
 	public static final String DL_FILE_ENTRY_COMMENTS_ENABLED = "dl.file.entry.comments.enabled";

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -371,6 +371,7 @@
 		<friendly-url-mapping>image_gallery_display</friendly-url-mapping>
 		<friendly-url-routes>com/liferay/portlet/imagegallerydisplay/image-gallery-display-friendly-url-routes.xml</friendly-url-routes>
 		<portlet-data-handler-class>com.liferay.portlet.documentlibrary.lar.DLDisplayPortletDataHandlerImpl</portlet-data-handler-class>
+		<portlet-display-template-handler>com.liferay.portlet.documentlibrary.template.DocumentLibraryPortletDisplayTemplateHandler</portlet-display-template-handler>
 		<webdav-storage-token>document_library</webdav-storage-token>
 		<webdav-storage-class>com.liferay.portlet.documentlibrary.webdav.DLWebDAVStorageImpl</webdav-storage-class>
 		<preferences-owned-by-group>true</preferences-owned-by-group>

--- a/portal-web/docroot/html/portlet/image_gallery_display/configuration.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/configuration.jsp
@@ -78,6 +78,27 @@ String redirect = ParamUtil.getString(request, "redirect");
 						rightTitle="available"
 					/>
 				</aui:field-wrapper>
+
+				<div class="display-template">
+
+					<%
+					PortletDisplayTemplateHandler portletDisplayTemplateHandler = PortletDisplayTemplateHandlerRegistryUtil.getPortletDisplayTemplateHandler(FileEntry.class.getName());
+					%>
+
+					<liferay-ui:ddm-template-menu
+						classNameId="<%= PortalUtil.getClassNameId(portletDisplayTemplateHandler.getClassName()) %>"
+						preferenceName="displayTemplate"
+						preferenceValue="<%= displayTemplate %>"
+						showEmptyOption="<%= true %>"
+					/>
+
+					<liferay-ui:ddm-template-selector
+						classNameId="<%= PortalUtil.getClassNameId(portletDisplayTemplateHandler.getClassName()) %>"
+						message='<%= LanguageUtil.format(pageContext, "manage-display-templates-for-x", themeDisplay.getScopeGroupName(), false) %>'
+						refreshURL="<%= configurationURL %>"
+					/>
+				</div>
+
 			</aui:fieldset>
 		</liferay-ui:panel>
 

--- a/portal-web/docroot/html/portlet/image_gallery_display/init.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/init.jsp
@@ -16,7 +16,9 @@
 
 <%@ include file="/html/portlet/init.jsp" %>
 
-<%@ page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
+<%@ page import="com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateHandler" %><%@
+page import="com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateHandlerRegistryUtil" %><%@
+page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileVersion" %><%@
 page import="com.liferay.portal.kernel.repository.model.Folder" %><%@
 page import="com.liferay.portal.kernel.search.Document" %><%@
@@ -44,6 +46,7 @@ page import="com.liferay.portlet.documentlibrary.util.ImageProcessorUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.util.PDFProcessorUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.util.VideoProcessorUtil" %><%@
 page import="com.liferay.portlet.imagegallerydisplay.util.IGUtil" %><%@
+page import="com.liferay.portlet.portletdisplaytemplate.util.PortletDisplayTemplateUtil" %><%@
 page import="com.liferay.portlet.trash.util.TrashUtil" %>
 
 <%
@@ -86,6 +89,8 @@ boolean showTabs = PrefsParamUtil.getBoolean(preferences, request, "showTabs");
 
 boolean enableRatings = GetterUtil.getBoolean(preferences.getValue("enableRatings", null), true);
 boolean enableCommentRatings = GetterUtil.getBoolean(preferences.getValue("enableCommentRatings", null), true);
+
+String displayTemplate = preferences.getValue("displayTemplate", StringPool.BLANK);
 
 Format dateFormatDate = FastDateFormatFactoryUtil.getDate(locale, timeZone);
 %>

--- a/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/html/portlet/image_gallery_display/init.jsp" %>
 
 <%
-String topLink = ParamUtil.getString(request, "topLink", "home");
-
 Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long defaultFolderId = GetterUtil.getLong(preferences.getValue("rootFolderId", StringPool.BLANK), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -46,217 +44,244 @@ if (permissionChecker.isCompanyAdmin() || permissionChecker.isGroupAdmin(scopeGr
 	status = WorkflowConstants.STATUS_ANY;
 }
 
-long assetCategoryId = ParamUtil.getLong(request, "categoryId");
-String assetTagName = ParamUtil.getString(request, "tag");
+String[] mediaGalleryMimeTypes = DLUtil.getMediaGalleryMimeTypes(preferences, renderRequest);
 
-boolean useAssetEntryQuery = (assetCategoryId > 0) || Validator.isNotNull(assetTagName);
-
-PortletURL portletURL = renderResponse.createRenderURL();
-
-portletURL.setParameter("struts_action", "/image_gallery_display/view");
-portletURL.setParameter("topLink", topLink);
-portletURL.setParameter("folderId", String.valueOf(folderId));
-
-request.setAttribute("view.jsp-folder", folder);
-
-request.setAttribute("view.jsp-defaultFolderId", String.valueOf(defaultFolderId));
-
-request.setAttribute("view.jsp-folderId", String.valueOf(folderId));
-
-request.setAttribute("view.jsp-repositoryId", String.valueOf(repositoryId));
-
-request.setAttribute("view.jsp-viewFolder", Boolean.TRUE.toString());
-
-request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntryQuery));
-
-request.setAttribute("view.jsp-portletURL", portletURL);
+long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(themeDisplay, displayTemplate);
 %>
 
-<portlet:actionURL var="undoTrashURL">
-	<portlet:param name="struts_action" value="/document_library/edit_entry" />
-	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
-</portlet:actionURL>
-
-<liferay-ui:trash-undo portletURL="<%= undoTrashURL %>" />
-
-<liferay-util:include page="/html/portlet/document_library/top_links.jsp" />
-
 <c:choose>
-	<c:when test="<%= useAssetEntryQuery %>">
-		<liferay-ui:categorization-filter
-			assetType="images"
-			portletURL="<%= portletURL %>"
-		/>
+	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
 
 		<%
-		SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+		List fileEntries = DLAppServiceUtil.getGroupFileEntries(scopeGroupId, themeDisplay.getUserId(), folderId, mediaGalleryMimeTypes, status, 0, SearchContainer.DEFAULT_DELTA, null);
 
-		long[] classNameIds = {PortalUtil.getClassNameId(DLFileEntryConstants.getClassName()), PortalUtil.getClassNameId(DLFileShortcut.class.getName())};
+		String[] audioMimeTypes = ArrayUtil.toStringArray(AudioProcessorUtil.getAudioMimeTypes().toArray());
+		String[] videoMimeTypes = ArrayUtil.toStringArray(VideoProcessorUtil.getVideoMimeTypes().toArray());
 
-		AssetEntryQuery assetEntryQuery = new AssetEntryQuery(classNameIds, searchContainer);
+		Map<String, Object> contextObjects = new HashMap<String, Object>();
 
-		assetEntryQuery.setExcludeZeroViewCount(false);
-
-		int total = AssetEntryServiceUtil.getEntriesCount(assetEntryQuery);
-
-		searchContainer.setTotal(total);
-
-		List results = AssetEntryServiceUtil.getEntries(assetEntryQuery);
-
-		searchContainer.setResults(results);
-
-		String[] mediaGalleryMimeTypes = null;
-
-		request.setAttribute("view.jsp-folderId", folderId);
-		request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
-		request.setAttribute("view.jsp-results", results);
-		request.setAttribute("view.jsp-searchContainer", searchContainer);
+		contextObjects.put("audioMimeTypes", audioMimeTypes);
+		contextObjects.put("videoMimeTypes", videoMimeTypes);
 		%>
 
-		<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
+		<%= PortletDisplayTemplateUtil.renderDDMTemplate(pageContext, portletDisplayDDMTemplateId, fileEntries, contextObjects) %>
 	</c:when>
-	<c:when test='<%= topLink.equals("home") %>'>
-		<aui:layout>
-			<c:if test="<%= folder != null %>">
-				<liferay-ui:header
-					localizeTitle="<%= false %>"
-					title="<%= folder.getName() %>"
+	<c:otherwise>
+
+		<%
+		String topLink = ParamUtil.getString(request, "topLink", "home");
+
+		long assetCategoryId = ParamUtil.getLong(request, "categoryId");
+		String assetTagName = ParamUtil.getString(request, "tag");
+
+		boolean useAssetEntryQuery = (assetCategoryId > 0) || Validator.isNotNull(assetTagName);
+
+		PortletURL portletURL = renderResponse.createRenderURL();
+
+		portletURL.setParameter("struts_action", "/image_gallery_display/view");
+		portletURL.setParameter("topLink", topLink);
+		portletURL.setParameter("folderId", String.valueOf(folderId));
+
+		request.setAttribute("view.jsp-folder", folder);
+
+		request.setAttribute("view.jsp-defaultFolderId", String.valueOf(defaultFolderId));
+
+		request.setAttribute("view.jsp-folderId", String.valueOf(folderId));
+
+		request.setAttribute("view.jsp-repositoryId", String.valueOf(repositoryId));
+
+		request.setAttribute("view.jsp-viewFolder", Boolean.TRUE.toString());
+
+		request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntryQuery));
+
+		request.setAttribute("view.jsp-portletURL", portletURL);
+		%>
+
+		<portlet:actionURL var="undoTrashURL">
+			<portlet:param name="struts_action" value="/document_library/edit_entry" />
+			<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:trash-undo portletURL="<%= undoTrashURL %>" />
+
+		<liferay-util:include page="/html/portlet/document_library/top_links.jsp" />
+
+		<c:choose>
+			<c:when test="<%= useAssetEntryQuery %>">
+				<liferay-ui:categorization-filter
+					assetType="images"
+					portletURL="<%= portletURL %>"
 				/>
-			</c:if>
 
-			<%
-			SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+				<%
+				SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
 
-			String[] mediaGalleryMimeTypes = DLUtil.getMediaGalleryMimeTypes(preferences, renderRequest);
+				long[] classNameIds = {PortalUtil.getClassNameId(DLFileEntryConstants.getClassName()), PortalUtil.getClassNameId(DLFileShortcut.class.getName())};
 
-			int foldersCount = DLAppServiceUtil.getFoldersCount(repositoryId, folderId, true);
+				AssetEntryQuery assetEntryQuery = new AssetEntryQuery(classNameIds, searchContainer);
 
-			int total = DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(repositoryId, folderId, status, mediaGalleryMimeTypes, true);
+				assetEntryQuery.setExcludeZeroViewCount(false);
 
-			int imagesCount = total - foldersCount;
+				int total = AssetEntryServiceUtil.getEntriesCount(assetEntryQuery);
 
-			searchContainer.setTotal(total);
+				searchContainer.setTotal(total);
 
-			List results = DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(repositoryId, folderId, status, mediaGalleryMimeTypes, true, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+				List results = AssetEntryServiceUtil.getEntries(assetEntryQuery);
 
-			searchContainer.setResults(results);
+				searchContainer.setResults(results);
 
-			request.setAttribute("view.jsp-folderId", folderId);
-			request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
-			request.setAttribute("view.jsp-results", results);
-			request.setAttribute("view.jsp-searchContainer", searchContainer);
-			%>
+				mediaGalleryMimeTypes = null;
 
-			<aui:column columnWidth="<%= showFolderMenu ? 75 : 100 %>" cssClass="lfr-asset-column lfr-asset-column-details" first="<%= true %>">
-				<div id="<portlet:namespace />imageGalleryAssetInfo">
+				request.setAttribute("view.jsp-folderId", folderId);
+				request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
+				request.setAttribute("view.jsp-results", results);
+				request.setAttribute("view.jsp-searchContainer", searchContainer);
+				%>
+
+				<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
+			</c:when>
+			<c:when test='<%= topLink.equals("home") %>'>
+				<aui:layout>
 					<c:if test="<%= folder != null %>">
-						<div class="lfr-asset-description">
-							<%= HtmlUtil.escape(folder.getDescription()) %>
-						</div>
-
-						<div class="lfr-asset-metadata">
-							<div class="lfr-asset-icon lfr-asset-date">
-								<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate())) %>
-							</div>
-
-							<div class="lfr-asset-icon lfr-asset-subfolders">
-								<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "subfolder" : "subfolders" %>' />
-							</div>
-
-							<div class="lfr-asset-icon lfr-asset-items last">
-								<%= imagesCount %> <liferay-ui:message key='<%= (imagesCount == 1) ? "image" : "images" %>' />
-							</div>
-						</div>
-
-						<liferay-ui:custom-attributes-available className="<%= DLFolderConstants.getClassName() %>">
-							<liferay-ui:custom-attribute-list
-								className="<%= DLFolderConstants.getClassName() %>"
-								classPK="<%= (folder != null) ? folder.getFolderId() : 0 %>"
-								editable="<%= false %>"
-								label="<%= true %>"
-							/>
-						</liferay-ui:custom-attributes-available>
+						<liferay-ui:header
+							localizeTitle="<%= false %>"
+							title="<%= folder.getName() %>"
+						/>
 					</c:if>
 
-					<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
-				</div>
-			</aui:column>
-
-			<c:if test="<%= showFolderMenu %>">
-				<aui:column columnWidth="<%= 25 %>" cssClass="lfr-asset-column lfr-asset-column-actions" last="<%= true %>">
-					<div class="lfr-asset-summary">
-						<liferay-ui:icon
-							cssClass="lfr-asset-avatar"
-							image='<%= "../file_system/large/" + ((total > 0) ? "folder_full_image" : "folder_empty") %>'
-							message='<%= (folder != null) ? folder.getName() : LanguageUtil.get(pageContext, "home") %>'
-						/>
-
-						<div class="lfr-asset-name">
-							<h4><%= (folder != null) ? folder.getName() : LanguageUtil.get(pageContext, "home") %></h4>
-						</div>
-					</div>
-
 					<%
-					request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
+					SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, "cur2", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+
+					int foldersCount = DLAppServiceUtil.getFoldersCount(repositoryId, folderId, true);
+
+					int total = DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(repositoryId, folderId, status, mediaGalleryMimeTypes, true);
+
+					int imagesCount = total - foldersCount;
+
+					searchContainer.setTotal(total);
+
+					List results = DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(repositoryId, folderId, status, mediaGalleryMimeTypes, true, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+
+					searchContainer.setResults(results);
+
+					request.setAttribute("view.jsp-folderId", folderId);
+					request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
+					request.setAttribute("view.jsp-results", results);
+					request.setAttribute("view.jsp-searchContainer", searchContainer);
 					%>
 
-					<liferay-util:include page="/html/portlet/document_library/folder_action.jsp" />
-				</aui:column>
-			</c:if>
-		</aui:layout>
+					<aui:column columnWidth="<%= showFolderMenu ? 75 : 100 %>" cssClass="lfr-asset-column lfr-asset-column-details" first="<%= true %>">
+						<div id="<portlet:namespace />imageGalleryAssetInfo">
+							<c:if test="<%= folder != null %>">
+								<div class="lfr-asset-description">
+									<%= HtmlUtil.escape(folder.getDescription()) %>
+								</div>
 
-		<%
-		if (folder != null) {
-			IGUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
+								<div class="lfr-asset-metadata">
+									<div class="lfr-asset-icon lfr-asset-date">
+										<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate())) %>
+									</div>
 
-			if (portletName.equals(PortletKeys.MEDIA_GALLERY_DISPLAY)) {
-				PortalUtil.setPageSubtitle(folder.getName(), request);
-				PortalUtil.setPageDescription(folder.getDescription(), request);
-			}
-		}
-		%>
+									<div class="lfr-asset-icon lfr-asset-subfolders">
+										<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "subfolder" : "subfolders" %>' />
+									</div>
 
-	</c:when>
-	<c:when test='<%= topLink.equals("mine") || topLink.equals("recent") %>'>
+									<div class="lfr-asset-icon lfr-asset-items last">
+										<%= imagesCount %> <liferay-ui:message key='<%= (imagesCount == 1) ? "image" : "images" %>' />
+									</div>
+								</div>
 
-		<%
-		long groupImagesUserId = 0;
+								<liferay-ui:custom-attributes-available className="<%= DLFolderConstants.getClassName() %>">
+									<liferay-ui:custom-attribute-list
+										className="<%= DLFolderConstants.getClassName() %>"
+										classPK="<%= (folder != null) ? folder.getFolderId() : 0 %>"
+										editable="<%= false %>"
+										label="<%= true %>"
+									/>
+								</liferay-ui:custom-attributes-available>
+							</c:if>
 
-		if (topLink.equals("mine") && themeDisplay.isSignedIn()) {
-			groupImagesUserId = user.getUserId();
-		}
+							<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
+						</div>
+					</aui:column>
 
-		SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+					<c:if test="<%= showFolderMenu %>">
+						<aui:column columnWidth="<%= 25 %>" cssClass="lfr-asset-column lfr-asset-column-actions" last="<%= true %>">
+							<div class="lfr-asset-summary">
+								<liferay-ui:icon
+									cssClass="lfr-asset-avatar"
+									image='<%= "../file_system/large/" + ((total > 0) ? "folder_full_image" : "folder_empty") %>'
+									message='<%= (folder != null) ? folder.getName() : LanguageUtil.get(pageContext, "home") %>'
+								/>
 
-		String[] mediaGalleryMimeTypes = DLUtil.getMediaGalleryMimeTypes(preferences, renderRequest);
+								<div class="lfr-asset-name">
+									<h4><%= (folder != null) ? folder.getName() : LanguageUtil.get(pageContext, "home") %></h4>
+								</div>
+							</div>
 
-		int total = DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupImagesUserId, defaultFolderId, mediaGalleryMimeTypes, status);
+							<%
+							request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
+							%>
 
-		searchContainer.setTotal(total);
+							<liferay-util:include page="/html/portlet/document_library/folder_action.jsp" />
+						</aui:column>
+					</c:if>
+				</aui:layout>
 
-		List results = DLAppServiceUtil.getGroupFileEntries(repositoryId, groupImagesUserId, defaultFolderId, mediaGalleryMimeTypes, status, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+				<%
+				if (folder != null) {
+					IGUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 
-		searchContainer.setResults(results);
+					if (portletName.equals(PortletKeys.MEDIA_GALLERY_DISPLAY)) {
+						PortalUtil.setPageSubtitle(folder.getName(), request);
+						PortalUtil.setPageDescription(folder.getDescription(), request);
+					}
+				}
+				%>
 
-		request.setAttribute("view.jsp-folderId", folderId);
-		request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
-		request.setAttribute("view.jsp-results", results);
-		request.setAttribute("view.jsp-searchContainer", searchContainer);
-		%>
+			</c:when>
+			<c:when test='<%= topLink.equals("mine") || topLink.equals("recent") %>'>
 
-		<aui:layout>
-			<liferay-ui:header
-				title="<%= topLink %>"
-			/>
+				<%
+				long groupImagesUserId = 0;
 
-			<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
-		</aui:layout>
+				if (topLink.equals("mine") && themeDisplay.isSignedIn()) {
+					groupImagesUserId = user.getUserId();
+				}
 
-		<%
-		PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, topLink), currentURL);
+				SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, null, null);
 
-		PortalUtil.setPageSubtitle(LanguageUtil.get(pageContext, topLink), request);
-		%>
+				mediaGalleryMimeTypes = DLUtil.getMediaGalleryMimeTypes(preferences, renderRequest);
 
-	</c:when>
+				int total = DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupImagesUserId, defaultFolderId, mediaGalleryMimeTypes, status);
+
+				searchContainer.setTotal(total);
+
+				List results = DLAppServiceUtil.getGroupFileEntries(repositoryId, groupImagesUserId, defaultFolderId, mediaGalleryMimeTypes, status, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+
+				searchContainer.setResults(results);
+
+				request.setAttribute("view.jsp-folderId", folderId);
+				request.setAttribute("view.jsp-mediaGalleryMimeTypes", mediaGalleryMimeTypes);
+				request.setAttribute("view.jsp-results", results);
+				request.setAttribute("view.jsp-searchContainer", searchContainer);
+				%>
+
+				<aui:layout>
+					<liferay-ui:header
+						title="<%= topLink %>"
+					/>
+
+					<liferay-util:include page="/html/portlet/image_gallery_display/view_images.jsp" />
+				</aui:layout>
+
+				<%
+				PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, topLink), currentURL);
+
+				PortalUtil.setPageSubtitle(LanguageUtil.get(pageContext, topLink), request);
+				%>
+
+			</c:when>
+		</c:choose>
+	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
The portet-display-template.xml is added but left empty. This way, all the necessary logic to install default ADT templates during portal startup is available, and sample templates will be added in later commits.

Since the Media Gallery portlet is mostly based in the Document and Media portlet, all the classes and dependencies have been added to the second. Besides, since the implementation of ADT for based in a list of FileEntry objects, the templates will be reusable for the Document and Media portlet, the Document and Media display Portlet and the Media Gallery portlet.

@ealonso
