### PR TITLE
LPS-31964 edit javadocs - no changes

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -64,23 +64,23 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * The DDM Structure local service is responsible for accessing, creating,
- * modifying and deleting structures.
+ * The Dynamic Data Mapping (DDM) Structure local service is responsible for accessing, creating,
+ * modifying, and deleting structures.
  *
  * <p>
- * Structures are used in Liferay to store structured content like document
- * types, dynamic data definitions or web contents
+ * DDM structures (structures) are used in Liferay to store structured content
+ * like document types, dynamic data definitions, or web contents.
  * </p>
  *
  * <p>
- * Structures support inheritance defined by the parentStructureId field. They
- * also support multi-language name and description.
+ * Structures support inheritance via parent structures. They also support
+ * multi-language names and descriptions.
  * </p>
  *
  * <p>
- * Structures can be related to many models in the portal, for instance Journal
- * Articles, Dynamic Data Lists or Documents. This relationship can be defined
- * using the model classNameId.
+ * Structures can be related to many models in Liferay, such as those for web
+ * contents, dynamic data lists, and documents. This relationship can be
+ * established via the model's class name ID.
  * </p>
  *
  * @author Brian Wing Shun Chan
@@ -91,31 +91,31 @@ public class DDMStructureLocalServiceImpl
 	extends DDMStructureLocalServiceBaseImpl {
 
 	/**
-	 * Adds a structure.
+	 * Adds a structure referencing its parent structure.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  groupId the primary key of the group
 	 * @param  parentStructureId the primary key of the parent structure
 	 *         (optionally {@link
 	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants#DEFAULT_PARENT_STRUCTURE_ID})
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @param  structureKey unique string identifying the structure (optionally
-	 *         <code>null</code>)
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  structureKey the unique string identifying the structure
+	 *         (optionally <code>null</code>)
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
-	 * @param  xsd the XML schema definition of the structure
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
-	 * @param  serviceContext the service context to be applied. Can set the
-	 *         UUID, creation date, modification date, guest permissions and
-	 *         group permissions for the structure.
+	 * @param  xsd the structure's XML schema definition
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
+	 * @param  serviceContext the structure's service context. Can set the UUID,
+	 *         creation date, modification date, guest permissions, and group
+	 *         permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if the creator user could not be found or if the
-	 *         xsd is not well formed
+	 * @throws PortalException if a user with the primary key could not be found, if the
+	 *         XSD was not well-formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -188,22 +188,23 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Adds a structure without parent structure, using the storage type defined
-	 * by the property "dynamic.data.lists.storage.type" from the
-	 * portal.properties file and using the default type.
+	 * Adds a structure referencing a default parent structure, using the portal
+	 * property <code>dynamic.data.lists.storage.type</code> storage type and
+	 * default structure type.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
-	 * @param  xsd the XML schema definition of the structure
-	 * @param  serviceContext the service context to be applied. Can set the
-	 *         UUID, creation date, modification date, guest permissions and
-	 *         group permissions for the structure.
+	 * @param  xsd the structure's XML schema definition
+	 * @param  serviceContext the structure's service context. Can set the UUID,
+	 *         creation date, modification date, guest permissions, and group
+	 *         permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if a portal exception occurred
+	 * @throws PortalException if a user with the primary key could not be found, if the XSD
+	 *         was not well-formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -220,30 +221,31 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Adds a structure referencing the parent structure by its structureKey. In
-	 * case the parent structure is not found, it uses the default parent
-	 * structure ID.
+	 * Adds a structure referencing a default parent structure if the parent
+	 * structure is not found.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  groupId the primary key of the group
-	 * @param  parentStructureKey unique string identifying the structure
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @param  structureKey unique string identifying the structure (optionally
-	 *         <code>null</code>)
+	 * @param  parentStructureKey the unique string identifying the parent
+	 *         structure (optionally <code>null</code>)
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  structureKey the unique string identifying the structure
+	 *         (optionally <code>null</code>)
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
-	 * @param  xsd the XML schema definition of the structure
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
-	 * @param  serviceContext the service context to be applied. Can set the
-	 *         UUID, creation date, modification date, guest permissions and
-	 *         group permissions for the structure.
+	 * @param  xsd the structure's XML schema definition
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
+	 * @param  serviceContext the structure's service context. Can set the UUID,
+	 *         creation date, modification date, guest permissions and group
+	 *         permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if a portal exception occurred
+	 * @throws PortalException if a user with the primary key could not be found, if the
+	 *         XSD was not well-formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -269,13 +271,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Adds the resources of a structure
+	 * Adds the resources to the structure.
 	 *
-	 * @param  structure the structure we are adding resources to
-	 * @param  addGroupPermissions set to <code>true</code> to add group
-	 *         permissions
-	 * @param  addGuestPermissions set to <code>true</code> to add guest
-	 *         permissions
+	 * @param  structure the structure to add resources to
+	 * @param  addGroupPermissions whether to add group permissions
+	 * @param  addGuestPermissions whether to add guest permissions
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -292,11 +292,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Adds the resources of a structure
+	 * Adds the model resources with the permissions to the structure.
 	 *
-	 * @param  structure the structure we are adding resources to
-	 * @param  groupPermissions group permissions to be added
-	 * @param  guestPermissions guest permissions to be added
+	 * @param  structure the structure to add resources to
+	 * @param  groupPermissions the group permissions to be added
+	 * @param  guestPermissions the guest permissions to be added
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -312,8 +312,9 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Copies a structure: creates a new structure extracting all the values
-	 * from the original one. Supports defining the new name and description.
+	 * Copies a structure, creating a new structure with all the values
+	 * extracted from the original one. The new structure supports a new name
+	 * and description.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  structureId the primary key of the structure to be copied
@@ -321,9 +322,9 @@ public class DDMStructureLocalServiceImpl
 	 * @param  descriptionMap the new structure's locales and localized
 	 *         descriptions
 	 * @param  serviceContext the service context to be applied. Can set the
-	 *         UUID, creation date, modification date, guest permissions and
+	 *         UUID, creation date, modification date, guest permissions, and
 	 *         group permissions for the structure.
-	 * @return the structure
+	 * @return the new structure
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -343,13 +344,14 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Deletes a structure and its resources.
+	 * Deletes the structure and its resources.
 	 *
-	 * Before deleting the structure, this method validates if the structure is
-	 * required by another entity. In case it is needed it will throw an
-	 * exception.
+	 * <p>
+	 * Before deleting the structure, this method verifies whether the structure
+	 * is required by another entity. If it is needed, an exception is thrown.
+	 * </p>
 	 *
-	 * @param  structure the structure that will be deleted
+	 * @param  structure the structure to be deleted
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -385,13 +387,14 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Deletes a structure and its resources.
+	 * Deletes the structure and its resources.
 	 *
-	 * Before deleting the structure, the system validates if the structure is
-	 * required by another entity. In case it is needed it will throw an
-	 * exception.
+	 * <p>
+	 * Before deleting the structure, the system verifies whether the structure
+	 * is required by another entity. If it is needed, an exception is thrown.
+	 * </p>
 	 *
-	 * @param  structureId the primary key of the structure that will be deleted
+	 * @param  structureId the primary key of the structure to be deleted
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -405,14 +408,15 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Deletes a structure and its resources.
+	 * Deletes the matching structure and its resources.
 	 *
-	 * Before deleting the structure, the system validates if the structure is
-	 * required by another entity. In case it is needed it will throw an
-	 * exception.
+	 * <p>
+	 * Before deleting the structure, the system verifies whether the structure
+	 * is required by another entity. If it is needed, an exception is thrown.
+	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -428,11 +432,13 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Deletes all the structures of a group
+	 * Deletes all the structures of the group.
 	 *
-	 * Before deleting the structures, the system validates if each structure is
-	 * required by another entity. In case it is needed it will throw an
-	 * exception.
+	 * <p>
+	 * Before deleting the structures, the system verifies whether each
+	 * structure is required by another entity. If any of the structures are
+	 * needed, an exception is thrown.
+	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
 	 * @throws PortalException if a portal exception occurred
@@ -450,10 +456,10 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the structure with the matching structureId.
+	 * Returns the structure with the ID.
 	 *
 	 * @param  structureId the primary key of the structure
-	 * @return the structure with the structureId, or <code>null</code> if a
+	 * @return the structure with the structure ID, or <code>null</code> if a
 	 *         matching structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -464,12 +470,12 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the structure with the matching structureKey in a given group.
+	 * Returns the structure matching the structure key and group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  structureKey unique string identifying the structure
-	 * @return the structure with the structure key in the group, or
-	 *         <code>null</code> if a matching structure could not be found
+	 * @param  structureKey the unique string identifying the structure
+	 * @return the matching structure, or <code>null</code> if a matching
+	 *         structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure fetchStructure(long groupId, String structureKey)
@@ -481,20 +487,21 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the structure with the matching structureKey in a given group and
-	 * optionally in the global scope.
+	 * Returns the structure matching the structure key and group, optionally in
+	 * the global scope.
 	 *
-	 * This method first searches in the give group and in case the structure is
-	 * not found and includeGlobalStructures is set to <code>true</code>, then
-	 * searches the
-	 * global group.
+	 * <p>
+	 * This method first searches in the group. If the structure is still not
+	 * found and <code>includeGlobalStructures</code> is set to
+	 * <code>true</code>, this method searches the global group.
+	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @param  includeGlobalStructures whether to include the global scope in
 	 *         the search
-	 * @return the structure or <code>null</code> if a matching structure could
-	 *         not be found
+	 * @return the matching structure, or <code>null</code> if a matching
+	 *         structure could not be found
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -521,11 +528,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the structure with the matching uuid in a group.
+	 * Returns the structure matching the UUID and group.
 	 *
-	 * @param  uuid the structure'd UUID
+	 * @param  uuid the structure's UUID
 	 * @param  groupId the primary key of the structure's group
-	 * @return the structure with the uuid, or <code>null</code> if a matching
+	 * @return the matching structure, or <code>null</code> if a matching
 	 *         structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -556,13 +563,12 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a list of structures with the matching classNameId in a given
-	 * company.
+	 * Returns all the structures matching the class name ID.
 	 *
-	 * @param  companyId the primary key of the structures company
-	 * @param  classNameId the class name ID of the structures
-	 * @return a list of structures with the matching classNameId in a given
-	 *         company.
+	 * @param  companyId the primary key of the structure's company
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @return the structures matching the class name ID
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getClassStructures(
@@ -573,8 +579,7 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a range of all the structures belonging to a given company and
-	 * has this classNameId
+	 * Returns a range of all the structures matching the class name ID.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -586,11 +591,13 @@ public class DDMStructureLocalServiceImpl
 	 * result set.
 	 * </p>
 	 *
-	 * @param  companyId the primary key of the structures company
-	 * @param  classNameId the class name ID of the structures
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @return the matching structures
+	 * @param  companyId the primary key of the structure's company
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @return the range of matching structures
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getClassStructures(
@@ -602,15 +609,15 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns all the structures belonging to a given company and has this
-	 * classNameId
+	 * Returns all the structures matching the class name ID ordered by the
+	 * comparator.
 	 *
-	 * @param  companyId the primary key of the structures company
-	 * @param  classNameId the class name ID of the structures
-	 * @param  orderByComparator the comparator to order the results by
+	 * @param  companyId the primary key of the structure's company
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getClassStructures(
@@ -636,10 +643,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a list of structures for a given document library file entry type
+	 * Returns all the structures for the document library file entry type.
 	 *
-	 * @param  dlFileEntryTypeId the primary key of the file entry type
-	 * @return the matching structures
+	 * @param  dlFileEntryTypeId the primary key of the document library file
+	 *         entry type
+	 * @return the structures for the document library file entry type
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getDLFileEntryTypeStructures(
@@ -650,11 +658,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a structure that has a matching primary key
+	 * Returns the structure with the ID.
 	 *
 	 * @param  structureId the primary key of the structure
-	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @return the structure with the ID
+	 * @throws PortalException if a structure with the ID could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(long structureId)
@@ -664,12 +672,12 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a structure that has a matching structure key in a given group
+	 * Returns the structure matching the structure key and group.
 	 *
 	 * @param  groupId the primary key of the structure's group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @throws PortalException if a matching structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(long groupId, String structureKey)
@@ -681,20 +689,21 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a structure that has a matching structure key in a given group
-	 * and optionally in the global scope.
+	 * Returns the structure matching the structure key and group, optionally in
+	 * the global scope.
 	 *
-	 * This method first searches in the give group and in case the structure is
-	 * not found and includeGlobalStructures is set to <code>true</code>, then
-	 * searches the
-	 * global group.
+	 * <p>
+	 * This method first searches in the group. If the structure is still not
+	 * found and <code>includeGlobalStructures</code> is set to
+	 * <code>true</code>, this method searches the global group.
+	 * </p>
 	 *
 	 * @param  groupId the primary key of the structure's group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @param  includeGlobalStructures whether to include the global scope in
 	 *         the search
 	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @throws PortalException if a matching structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(
@@ -726,8 +735,7 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a list of structures that matches a given name and description in
-	 * a group
+	 * Returns all the structures matching the group, name, and description.
 	 *
 	 * @param  groupId the primary key of the structure's group
 	 * @param  name the structure's name
@@ -769,9 +777,9 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a list with all the structures present in the system
+	 * Returns all the structures present in the system.
 	 *
-	 * @return the structures
+	 * @return the structures present in the system
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures() throws SystemException {
@@ -779,10 +787,10 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a list with all the structure present in a group
+	 * Returns all the structures present in the group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @return the list of structures in the group
+	 * @return the structures present in the group
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(long groupId)
@@ -805,10 +813,11 @@ public class DDMStructureLocalServiceImpl
 	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @return the matching structures, or <code>null</code> if no matches were
-	 *         found
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @return the range of matching structures, or <code>null</code> if no
+	 *         matches could be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(long groupId, int start, int end)
@@ -818,12 +827,11 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns all structures that matches the class name ID and belong to the
-	 * group
+	 * Returns all the structures matching class name ID and group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
 	 * @return the matching structures
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -834,8 +842,8 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a range of all structures that matches the class name ID and
-	 * belong to the group
+	 * Returns a range of all the structures that match the class name ID and
+	 * group.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -848,12 +856,13 @@ public class DDMStructureLocalServiceImpl
 	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @return the matching structures, or <code>null</code> if no matches were
-	 *         found
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @return the matching structures, or <code>null</code> if no matching
+	 *         structures could be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(
@@ -865,8 +874,8 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns a range of all structures that matches the class name ID and
-	 * belong to the group
+	 * Returns an ordered range of all the structures matching the class name ID
+	 * and group.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -879,14 +888,14 @@ public class DDMStructureLocalServiceImpl
 	 * </p>
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @param  orderByComparator the comparator to order the results by
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the range of matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(
@@ -899,10 +908,10 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the list of structures that belong to the groups
+	 * Returns all the structures belonging to the groups.
 	 *
-	 * @param  groupIds the primary key of the groups
-	 * @return the list of structures that belongs to the groups
+	 * @param  groupIds the primary keys of the groups
+	 * @return the structures belonging to the groups
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(long[] groupIds)
@@ -912,10 +921,10 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the number of structures that belong to the group
+	 * Returns the number of structures belonging to the group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @return the number of structures that belong to the group
+	 * @return the number of structures belonging to the group
 	 * @throws SystemException if a system exception occurred
 	 */
 	public int getStructuresCount(long groupId) throws SystemException {
@@ -923,14 +932,12 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the number of structures that belong to the group and matches the
-	 * class name ID
+	 * Returns the number of structures matching the class name ID and group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @return the number of structures that belong to the group and matches the
-	 *         class name ID
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @return the number of matching structures
 	 * @throws SystemException if a system exception occurred
 	 */
 	public int getStructuresCount(long groupId, long classNameId)
@@ -940,9 +947,9 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns an ordered range of all the structures belonging to the company
-	 * and groups that matches the class names IDs and include the keywords on
-	 * its names or descriptions
+	 * Returns an ordered range of all the structures matching the groups and
+	 * class name IDs, and matching the keywords in the structure names and
+	 * descriptions.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -954,18 +961,18 @@ public class DDMStructureLocalServiceImpl
 	 * result set.
 	 * </p>
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
 	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         structure's name, or description (optionally <code>null</code>)
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @param  orderByComparator the comparator to order the results by
+	 *         structure's name or description (optionally <code>null</code>)
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the range of matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> search(
@@ -980,9 +987,8 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns an ordered range of all the structures belonging to the company
-	 * and groups that matches the class names IDs and include the keywords on
-	 * its names or descriptions, matches storage type or type
+	 * Returns an ordered range of all the structures matching the groups, class
+	 * name IDs, name keyword, description keyword, storage type, and type.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -994,25 +1000,25 @@ public class DDMStructureLocalServiceImpl
 	 * result set.
 	 * </p>
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
-	 * @param  name the structure's name
-	 * @param  description the structure's description
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
+	 * @param  name the name keywords
+	 * @param  description the description keywords
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
 	 * @param  andOperator whether every field must match its keywords, or just
-	 *         one field.
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @param  orderByComparator the comparator to order the results by
+	 *         one field
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the range of matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> search(
@@ -1028,18 +1034,17 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the number of structures belonging to the company and groups that
-	 * matches the class names IDs and include the keywords on its names or
-	 * descriptions
+	 * Returns the number of structures matching the groups and class name IDs,
+	 * and matching the keywords in the structure names and descriptions.
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
 	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         structure's name, or description (optionally <code>null</code>)
+	 *         structure's name or description (optionally <code>null</code>)
 	 * @return the number of matching structures
-	 * @throws
+	 * @throws SystemException if a system exception occurred
 	 */
 	public int searchCount(
 			long companyId, long[] groupIds, long[] classNameIds,
@@ -1051,23 +1056,22 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Returns the number of structures belonging to the company and groups that
-	 * matches the class names IDs and include the keywords on its names or
-	 * descriptions, matches storage type or type
+	 * Returns the number of structures matching the groups, class name IDs,
+	 * name keyword, description keyword, storage type, and type
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
-	 *         the structures are related to
-	 * @param  name the structure's name
-	 * @param  description the structure's description
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
+	 *         the structure's are related to
+	 * @param  name the name keywords
+	 * @param  description the description keywords
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
 	 * @param  andOperator whether every field must match its keywords, or just
-	 *         one field.
+	 *         one field
 	 * @return the number of matching structures
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -1083,17 +1087,17 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Updates the structure replacing the old parentStructureId, nameMap,
-	 * descriptionMap and xsd with the new ones
+	 * Updates the structure replacing its old parent structure, name map,
+	 * description map, and XSD with new ones.
 	 *
 	 * @param  structureId the primary key of the structure
-	 * @param  parentStructureId the new parentStructureId
+	 * @param  parentStructureId the primary key of the new parent structure
 	 * @param  nameMap the structure's new locales and localized names
 	 * @param  descriptionMap the structure's new locales and localized
 	 *         description
-	 * @param  xsd the new XML schema definition of the structure
+	 * @param  xsd the structure's new XML schema definition
 	 * @param  serviceContext the service context to be applied. Can set the
-	 *         modification date
+	 *         modification date.
 	 * @return the updated structure
 	 * @throws PortalException if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
@@ -1113,16 +1117,16 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	/**
-	 * Updates the structure matching the structure key and group replacing the
-	 * old parentStructureId, nameMap, descriptionMap and xsd with the new ones
+	 * Updates the structure matching the structure key and group, replacing its
+	 * old parent structure, name map, description map, and XSD with new ones.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  parentStructureId the new parentStructureId
+	 * @param  parentStructureId the primary key of the new parent structure
 	 * @param  structureKey unique string identifying the structure
 	 * @param  nameMap the structure's new locales and localized names
 	 * @param  descriptionMap the structure's new locales and localized
-	 *         description
-	 * @param  xsd the new XML schema definition of the structure
+	 *         descriptions
+	 * @param  xsd the structure's new XML schema definition
 	 * @param  serviceContext the service context to be applied. Can set the
 	 *         modification date
 	 * @return the updated structure

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureServiceImpl.java
@@ -30,36 +30,35 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * The DDM Structure service is responsible for accessing, creating, modifying
- * and deleting structures.
- *
- * For more information on ddm structures, see
- * {@link
- * com.liferay.portlet.dynamicdatamapping.service.impl.DDMStructureLocalServiceImpl}.
+ * The Dynamic Data Mapping (DDM) Structure service is responsible for
+ * accessing, creating, modifying, and deleting structures.
  *
  * @author Brian Wing Shun Chan
  * @author Bruno Basto
  * @author Marcellus Tavares
+ * @see    com.liferay.portlet.dynamicdatamapping.service.impl.DDMStructureLocalServiceImpl
  */
 public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 
 	/**
-	 * Adds a structure.
+	 * Adds a structure referencing a default parent structure, using the portal
+	 * property <code>dynamic.data.lists.storage.type</code> storage type and
+	 * default structure type.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  groupId the primary key of the group
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
-	 * @param  xsd the XML schema definition of the structure
-	 * @param  serviceContext the service context to be applied. Must have the
-	 *         ddmResource attribute to check permissions. Can set the UUID,
-	 *         creation date, modification date, guest permissions and group
+	 * @param  xsd the structure's XML schema definition
+	 * @param  serviceContext the structure's service context. Can set the UUID,
+	 *         creation date, modification date, guest permissions, and group
 	 *         permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if the creator user could not be found or if the
-	 *         xsd is not well formed
+	 * @throws PortalException if a user with the primary key could not be found, if the
+	 *         user did not have permission to add the structure, if the
+	 *         XSD was not well-formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -80,31 +79,31 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Adds a structure.
+	 * Adds a structure referencing its parent structure.
 	 *
 	 * @param  groupId the primary key of the group
 	 * @param  parentStructureId the primary key of the parent structure
 	 *         (optionally {@link
 	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants#DEFAULT_PARENT_STRUCTURE_ID})
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
-	 * @param  structureKey unique string identifying the structure (optionally
-	 *         <code>null</code>)
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
+	 * @param  structureKey the unique string identifying the structure
+	 *         (optionally <code>null</code>)
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
-	 * @param  xsd the XML schema definition of the structure
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
-	 * @param  serviceContext the service context to be applied. Must have the
-	 *         ddmResource attribute to check permissions. Can set the UUID,
-	 *         creation date, modification date, guest permissions and group
-	 *         permissions for the structure
+	 * @param  xsd the structure's XML schema definition
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
+	 * @param  serviceContext the structure's service context. Can set the UUID,
+	 *         creation date, modification date, guest permissions, and group
+	 *         permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if the creator user could not be found or if the
-	 *         xsd is not well formed
+	 * @throws PortalException if the
+	 *         user did not have permission to add the structure, if the
+	 *         XSD is not well formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -126,31 +125,33 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Adds a structure referencing the parent structure by its structureKey. In
-	 * case the parent structure is not found, it uses the default parent
+	 * Adds a structure referencing the parent structure by its structure key.
+	 * In case the parent structure is not found, it uses the default parent
 	 * structure ID.
 	 *
 	 * @param  userId the primary key of the structure's creator/owner
 	 * @param  groupId the primary key of the group
-	 * @param  parentStructureKey unique string identifying the structure
-	 * @param  classNameId the primary key of the class name of the model the
-	 *         structure is related to
+	 * @param  parentStructureKey the unique string identifying the structure
+	 * @param  classNameId the primary key of the class name for the structure's
+	 *         related model
 	 * @param  structureKey unique string identifying the structure (optionally
 	 *         <code>null</code>)
 	 * @param  nameMap the structure's locales and localized names
 	 * @param  descriptionMap the structure's locales and localized descriptions
 	 * @param  xsd the XML schema definition of the structure
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
+	 * @param  storageType the storage type of the structure. It can be XML or
+	 *         expando. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
 	 * @param  serviceContext the service context to be applied. Must have the
-	 *         ddmResource attribute to check permissions. Can set the UUID,
-	 *         creation date, modification date, guest permissions and group
-	 *         permissions for the structure
+	 *         <code>ddmResource</code> attribute to check permissions. Can set
+	 *         the UUID, creation date, modification date, guest permissions,
+	 *         and group permissions for the structure.
 	 * @return the structure
-	 * @throws PortalException if a portal exception occurred
+	 * @throws PortalException if a user with the primary key could not be found, if the
+	 *         user did not have permission to add the structure, if the
+	 *         XSD was not well-formed, or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure addStructure(
@@ -172,19 +173,20 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Copies a structure: creates a new structure extracting all the values
-	 * from the original one. Supports defining the new name and description.
+	 * Copies a structure, creating a new structure with all the values
+	 * extracted from the original one. The new structure supports a new name
+	 * and description.
 	 *
 	 * @param  structureId the primary key of the structure to be copied
 	 * @param  nameMap the new structure's locales and localized names
 	 * @param  descriptionMap the new structure's locales and localized
 	 *         descriptions
-	 * @param  serviceContext the service context to be applied. Must have the
-	 *         ddmResource attribute to check permissions. Can set the UUID,
-	 *         creation date, modification date, guest permissions and group
-	 *         permissions for the structure
-	 * @return the structure
-	 * @throws PortalException if a portal exception occurred
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, guest permissions, and
+	 *         group permissions for the structure.
+	 * @return the new structure
+	 * @throws PortalException if the user did not have permission to add the
+	 *         structure or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure copyStructure(
@@ -203,14 +205,16 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Deletes a structure and its resources.
+	 * Deletes the structure and its resources.
 	 *
-	 * Before deleting the structure, the system validates if the structure is
-	 * required by another entity. In case it is needed it will throw an
-	 * exception.
+	 * <p>
+	 * Before deleting the structure, the system verifies whether the structure
+	 * is required by another entity. If it is needed, an exception is thrown.
+	 * </p>
 	 *
-	 * @param  structureId the primary key of the structure that will be deleted
-	 * @throws PortalException if a portal exception occurred
+	 * @param  structureId the primary key of the structure to be deleted
+	 * @throws PortalException if the user did not have permission to delete the
+	 *         structure or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public void deleteStructure(long structureId)
@@ -223,13 +227,14 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns the structure with the matching structureKey in a given group.
+	 * Returns the structure matching the structure key and group.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  structureKey unique string identifying the structure
-	 * @return the structure with the structure key in the group, or
-	 *         <code>null</code> if a matching structure could not be found
-	 * @throws
+	 * @param  structureKey the unique string identifying the structure
+	 * @return the matching structure, or <code>null</code> if a matching
+	 *         structure could not be found
+	 * @throws PortalException if the user did not have permission to view the
+	 *         structure or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure fetchStructure(long groupId, String structureKey)
@@ -247,11 +252,12 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns a structure that has a matching primary key
+	 * Returns the structure with the ID.
 	 *
 	 * @param  structureId the primary key of the structure
-	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @return the structure with the ID
+	 * @throws PortalException if the user did not have permission to view the
+	 *         structure or if a structure with the ID could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(long structureId)
@@ -264,12 +270,13 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns a structure that has a matching structure key in a given group
+	 * Returns the structure matching the structure key and group.
 	 *
 	 * @param  groupId the primary key of the structure's group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @throws PortalException if the user did not have permission to view the
+	 *         structure or if a matching structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(long groupId, String structureKey)
@@ -282,20 +289,22 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns a structure that has a matching structure key in a given group
-	 * and optionally in the global scope.
+	 * Returns the structure matching the structure key and group, optionally in
+	 * the global scope.
 	 *
-	 * This method first searches in the give group and in case the structure is
-	 * not found and includeGlobalStructures is set to <code>true</code>, then
-	 * searches the
-	 * global group.
+	 * <p>
+	 * This method first searches in the group. If the structure is still not
+	 * found and <code>includeGlobalStructures</code> is set to
+	 * <code>true</code>, this method searches the global group.
+	 * </p>
 	 *
 	 * @param  groupId the primary key of the structure's group
-	 * @param  structureKey unique string identifying the structure
+	 * @param  structureKey the unique string identifying the structure
 	 * @param  includeGlobalStructures whether to include the global scope in
 	 *         the search
 	 * @return the matching structure
-	 * @throws PortalException if the structure was not found
+	 * @throws PortalException if the user did not have permission to view the
+	 *         structure or if a matching structure could not be found
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure getStructure(
@@ -310,10 +319,11 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns a list with all the structure present in a group
+	 * Returns all the structures in the group that the user has permission to
+	 * view.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @return the list of structures in the group
+	 * @return the structures in the group that the user has permission to view
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(long groupId)
@@ -323,10 +333,11 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns the list of structures that belong to the groups
+	 * Returns all the structures in the groups that the user has permission to
+	 * view.
 	 *
 	 * @param  groupIds the primary key of the groups
-	 * @return the list of structures that belongs to the groups
+	 * @return the structures in the groups that the user has permission to view
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> getStructures(long[] groupIds)
@@ -336,9 +347,9 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns an ordered range of all the structures belonging to the company
-	 * and groups that matches the class names IDs and include the keywords on
-	 * its names or descriptions
+	 * Returns an ordered range of all the structures matching the groups and
+	 * class name IDs, and matching the keywords in the structure names and
+	 * descriptions.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -350,18 +361,18 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	 * result set.
 	 * </p>
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
 	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         structure's name, or description (optionally <code>null</code>)
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @param  orderByComparator the comparator to order the results by
+	 *         structure's name or description (optionally <code>null</code>)
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the range of matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> search(
@@ -376,9 +387,8 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns an ordered range of all the structures belonging to the company
-	 * and groups that matches the class names IDs and include the keywords on
-	 * its names or descriptions, matches storage type or type
+	 * Returns an ordered range of all the structures matching the groups, class
+	 * name IDs, name keyword, description keyword, storage type, and type.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end -
@@ -390,25 +400,25 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	 * result set.
 	 * </p>
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
-	 * @param  name the structure's name
-	 * @param  description the structure's description
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
+	 * @param  name the name keywords
+	 * @param  description the description keywords
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
 	 * @param  andOperator whether every field must match its keywords, or just
-	 *         one field.
-	 * @param  start the lower bound of the range of structures
-	 * @param  end the upper bound of the range of structures (not inclusive)
-	 * @param  orderByComparator the comparator to order the results by
+	 *         one field
+	 * @param  start the lower bound of the range of structures to return
+	 * @param  end the upper bound of the range of structures to return (not
+	 *         inclusive)
+	 * @param  orderByComparator the comparator to order the structures
 	 *         (optionally <code>null</code>)
-	 * @return the matching structures ordered by comparator
-	 *         <code>orderByComparator</code>
+	 * @return the range of matching structures ordered by the comparator
 	 * @throws SystemException if a system exception occurred
 	 */
 	public List<DDMStructure> search(
@@ -424,18 +434,17 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns the number of structures belonging to the company and groups that
-	 * matches the class names IDs and include the keywords on its names or
-	 * descriptions
+	 * Returns the number of structures matching the groups and class name IDs,
+	 * and matching the keywords in the structure names and descriptions.
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
 	 *         the structures are related to
 	 * @param  keywords the keywords (space separated), which may occur in the
-	 *         structure's name, or description (optionally <code>null</code>)
+	 *         structure's name or description (optionally <code>null</code>)
 	 * @return the number of matching structures
-	 * @throws
+	 * @throws SystemException if a system exception occurred
 	 */
 	public int searchCount(
 			long companyId, long[] groupIds, long[] classNameIds,
@@ -447,23 +456,22 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Returns the number of structures belonging to the company and groups that
-	 * matches the class names IDs and include the keywords on its names or
-	 * descriptions, matches storage type or type
+	 * Returns the number of structures matching the groups, class name IDs,
+	 * name keyword, description keyword, storage type, and type
 	 *
-	 * @param  companyId the primary key of the structures company
+	 * @param  companyId the primary key of the structure's company
 	 * @param  groupIds the primary keys of the groups
 	 * @param  classNameIds the primary keys of the class names of the models
-	 *         the structures are related to
-	 * @param  name the structure's name
-	 * @param  description the structure's description
-	 * @param  storageType the storage type of the structure. It can be "xml" or
-	 *         "expando". For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}
-	 * @param  type the structure's type. For more information see {@link
-	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}
+	 *         the structure's are related to
+	 * @param  name the name keywords
+	 * @param  description the description keywords
+	 * @param  storageType the structure's storage type. It can be "xml" or
+	 *         "expando". For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.storage.StorageType}.
+	 * @param  type the structure's type. For more information, see {@link
+	 *         com.liferay.portlet.dynamicdatamapping.model.DDMStructureConstants}.
 	 * @param  andOperator whether every field must match its keywords, or just
-	 *         one field.
+	 *         one field
 	 * @return the number of matching structures
 	 * @throws SystemException if a system exception occurred
 	 */
@@ -479,19 +487,20 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Updates the structure replacing the old parentStructureId, nameMap,
-	 * descriptionMap and xsd with the new ones
+	 * Updates the structure replacing its old parent structure, name map,
+	 * description map, and XSD with new ones.
 	 *
 	 * @param  structureId the primary key of the structure
-	 * @param  parentStructureId the new parentStructureId
+	 * @param  parentStructureId the primary key of the new parent structure
 	 * @param  nameMap the structure's new locales and localized names
 	 * @param  descriptionMap the structure's new locales and localized
 	 *         description
-	 * @param  xsd the new XML schema definition of the structure
+	 * @param  xsd the structure's new XML schema definition
 	 * @param  serviceContext the service context to be applied. Can set the
-	 *         modification date
+	 *         modification date.
 	 * @return the updated structure
-	 * @throws PortalException if a portal exception occurred
+	 * @throws PortalException if the user did not have permission to update the
+	 *         structure or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure updateStructure(
@@ -509,20 +518,22 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	}
 
 	/**
-	 * Updates the structure matching the structure key and group replacing the
-	 * old parentStructureId, nameMap, descriptionMap and xsd with the new ones
+	 * Updates the structure matching the structure key and group, replacing the
+	 * old parent structure ID, name map, description map, and XSD with the new
+	 * values.
 	 *
 	 * @param  groupId the primary key of the group
-	 * @param  parentStructureId the new parentStructureId
-	 * @param  structureKey unique string identifying the structure
+	 * @param  parentStructureId the new parent structure primary key
+	 * @param  structureKey the unique string identifying the structure
 	 * @param  nameMap the structure's new locales and localized names
 	 * @param  descriptionMap the structure's new locales and localized
 	 *         description
 	 * @param  xsd the new XML schema definition of the structure
 	 * @param  serviceContext the service context to be applied. Can set the
-	 *         modification date
+	 *         modification date.
 	 * @return the updated structure
-	 * @throws PortalException if a portal exception occurred
+	 * @throws PortalException if the user did not have permission to update the
+	 *         structure or if a portal exception occurred
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DDMStructure updateStructure(


### PR DESCRIPTION
Hi Juan, Here are the Javadoc edits @codyhoag and I made.

Note, with regards to the method descriptions, we took the approach of simply mentioning params (inlcuding keyword params). That is why you'll see the params mentioned together using "and". This is not intended to describe AND/OR logic, but simply to point out the set of params used in matching/finding structures. We left the AND/OR logic description to be done in the param descriptions. If AND/OR logic needs to be described more thoroughly, let's consider doing that in followup method description sentences or paragraphs. Hope that makes sense.

Thanks!
